### PR TITLE
fix: v0.1.10 QA improvements + bug hunting rounds 1-10

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build13
+// AiDesktopCompanion v0.1.10 build14
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build17
+// AiDesktopCompanion v0.1.10 build18
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build15
+// AiDesktopCompanion v0.1.10 build16
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build12
+// AiDesktopCompanion v0.1.10 build13
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build18
+// AiDesktopCompanion v0.1.10 build19
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build14
+// AiDesktopCompanion v0.1.10 build15
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build16
+// AiDesktopCompanion v0.1.10 build17
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run() {
       quick_actions::size_overlay_to_virtual_screen,
       quick_actions::capture_region,
       quick_actions::copy_text_to_clipboard,
+      quick_actions::dump_key_log,
       quick_actions::refocus_previous_app,
       mcp_connect,
       mcp_disconnect,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build19
+// AiDesktopCompanion v0.1.10 build20
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build20
+// AiDesktopCompanion v0.1.10 build21
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.10 build21
+// AiDesktopCompanion v0.1.10 build22
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/src/mcp.rs
+++ b/app/src-tauri/src/mcp.rs
@@ -292,6 +292,8 @@ pub fn summarize_input_schema(schema: &serde_json::Value) -> String {
 pub async fn build_openai_tools_from_mcp(
   clients: &std::collections::HashMap<String, Arc<RunningService<RoleClient, Box<dyn DynService<RoleClient>>>>>
 ) -> Vec<serde_json::Value> {
+  // Clear stale entries from previous builds to prevent routing to disconnected servers
+  if let Ok(mut map) = FN_REVERSE_MAP.lock() { map.clear(); }
   let mut out: Vec<serde_json::Value> = Vec::new();
   let disabled_map = crate::config::get_disabled_tools_map();
   for (server_id, svc) in clients.iter() {

--- a/app/src-tauri/src/mcp.rs
+++ b/app/src-tauri/src/mcp.rs
@@ -292,8 +292,8 @@ pub fn summarize_input_schema(schema: &serde_json::Value) -> String {
 pub async fn build_openai_tools_from_mcp(
   clients: &std::collections::HashMap<String, Arc<RunningService<RoleClient, Box<dyn DynService<RoleClient>>>>>
 ) -> Vec<serde_json::Value> {
-  // Clear stale entries from previous builds to prevent routing to disconnected servers
-  if let Ok(mut map) = FN_REVERSE_MAP.lock() { map.clear(); }
+  // Build into a new map, then swap atomically to avoid TOCTOU race with concurrent parse_mcp_fn_call_name
+  let mut new_reverse_map: std::collections::HashMap<String, (String, String)> = std::collections::HashMap::new();
   let mut out: Vec<serde_json::Value> = Vec::new();
   let disabled_map = crate::config::get_disabled_tools_map();
   for (server_id, svc) in clients.iter() {
@@ -323,9 +323,7 @@ pub async fn build_openai_tools_from_mcp(
               sanitize_fn_component(server_id),
               sanitize_fn_component(name));
             // Populate reverse lookup so parse_mcp_fn_call_name can recover original names
-            if let Ok(mut rmap) = FN_REVERSE_MAP.lock() {
-              rmap.insert(fn_name.clone(), (server_id.clone(), name.to_string()));
-            }
+            new_reverse_map.insert(fn_name.clone(), (server_id.clone(), name.to_string()));
             let inputs_summary = summarize_input_schema(&params);
             let desc_aug = if desc.is_empty() {
               if inputs_summary.is_empty() { format!("MCP tool '{}' from server '{}'.", name, server_id) }
@@ -343,5 +341,7 @@ pub async fn build_openai_tools_from_mcp(
       }
     }
   }
+  // Atomically swap the reverse map to avoid TOCTOU with concurrent parse_mcp_fn_call_name
+  if let Ok(mut rmap) = FN_REVERSE_MAP.lock() { *rmap = new_reverse_map; }
   out
 }

--- a/app/src-tauri/src/quick_actions.rs
+++ b/app/src-tauri/src/quick_actions.rs
@@ -314,6 +314,33 @@ pub fn capture_region(app: tauri::AppHandle, x: i32, y: i32, width: i32, height:
 }
 
 // TTS selection flow (moved from lib.rs)
+
+/// Dump debug text to a log file in the app config directory.
+/// Returns the full path of the written file.
+#[tauri::command]
+pub fn dump_key_log(text: String) -> Result<String, String> {
+  let dir = if let Ok(appdata) = std::env::var("APPDATA") {
+    let mut p = std::path::PathBuf::from(appdata);
+    p.push("AiDesktopCompanion");
+    p
+  } else {
+    return Err("APPDATA not set".into());
+  };
+  let _ = std::fs::create_dir_all(&dir);
+  let path = dir.join("qa_key_log.txt");
+  // Append with timestamp header
+  let header = format!("\n===== {} =====\n", chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"));
+  let content = format!("{}{}\n", header, text);
+  use std::io::Write;
+  let mut f = std::fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .open(&path)
+    .map_err(|e| format!("open failed: {e}"))?;
+  f.write_all(content.as_bytes()).map_err(|e| format!("write failed: {e}"))?;
+  Ok(path.to_string_lossy().to_string())
+}
+
 #[tauri::command]
 pub async fn tts_selection(app: tauri::AppHandle, safe_mode: Option<bool>) -> Result<String, String> {
   let safe = safe_mode.unwrap_or(false);

--- a/app/src-tauri/src/quick_actions.rs
+++ b/app/src-tauri/src/quick_actions.rs
@@ -319,15 +319,33 @@ pub fn capture_region(app: tauri::AppHandle, x: i32, y: i32, width: i32, height:
 /// Returns the full path of the written file.
 #[tauri::command]
 pub fn dump_key_log(text: String) -> Result<String, String> {
-  let dir = if let Ok(appdata) = std::env::var("APPDATA") {
-    let mut p = std::path::PathBuf::from(appdata);
-    p.push("AiDesktopCompanion");
-    p
-  } else {
-    return Err("APPDATA not set".into());
-  };
+  let dir = {
+    #[cfg(target_os = "windows")]
+    {
+      std::env::var("APPDATA").ok().map(|a| {
+        let mut p = std::path::PathBuf::from(a);
+        p.push("AiDesktopCompanion");
+        p
+      })
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+      std::env::var("HOME").ok().map(|h| {
+        let mut p = std::path::PathBuf::from(h);
+        p.push(".config");
+        p.push("AiDesktopCompanion");
+        p
+      })
+    }
+  }.ok_or_else(|| "Config directory not available".to_string())?;
   let _ = std::fs::create_dir_all(&dir);
   let path = dir.join("qa_key_log.txt");
+  // Truncate if file exceeds 1MB to prevent unbounded growth
+  if let Ok(meta) = std::fs::metadata(&path) {
+    if meta.len() > 1_048_576 {
+      let _ = std::fs::remove_file(&path);
+    }
+  }
   // Append with timestamp header
   let header = format!("\n===== {} =====\n", chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"));
   let content = format!("{}{}\n", header, text);

--- a/app/src-tauri/src/quick_actions.rs
+++ b/app/src-tauri/src/quick_actions.rs
@@ -363,23 +363,27 @@ pub fn dump_key_log(text: String) -> Result<String, String> {
 pub async fn tts_selection(app: tauri::AppHandle, safe_mode: Option<bool>) -> Result<String, String> {
   let safe = safe_mode.unwrap_or(false);
 
-  // Capture selection text similar to prompt_action
-  let mut clipboard = Clipboard::new().map_err(|e| format!("clipboard init failed: {e}"))?;
-  let previous_text = if !safe { clipboard.get_text().ok() } else { None };
+  // Clipboard + Enigo + sleep are blocking — run on a dedicated thread to avoid starving the async runtime
+  let selection = tokio::task::spawn_blocking(move || -> Result<String, String> {
+    let mut clipboard = Clipboard::new().map_err(|e| format!("clipboard init failed: {e}"))?;
+    let previous_text = if !safe { clipboard.get_text().ok() } else { None };
 
-  if !safe {
-    let mut enigo = Enigo::new();
-    enigo.key_down(Key::Control);
-    enigo.key_click(Key::Layout('c'));
-    enigo.key_up(Key::Control);
-    thread::sleep(Duration::from_millis(120));
-  }
+    if !safe {
+      let mut enigo = Enigo::new();
+      enigo.key_down(Key::Control);
+      enigo.key_click(Key::Layout('c'));
+      enigo.key_up(Key::Control);
+      thread::sleep(Duration::from_millis(120));
+    }
 
-  let selection = clipboard.get_text().unwrap_or_default();
+    let selection = clipboard.get_text().unwrap_or_default();
 
-  if !safe {
-    if let Some(prev) = previous_text { let _ = clipboard.set_text(prev); }
-  }
+    if !safe {
+      if let Some(prev) = previous_text { let _ = clipboard.set_text(prev); }
+    }
+
+    Ok(selection)
+  }).await.map_err(|e| format!("spawn_blocking failed: {e}"))??;
 
   if selection.trim().is_empty() {
     let _ = app.emit("tts:error", serde_json::json!({ "message": "No text selected" }));
@@ -407,10 +411,13 @@ pub async fn tts_selection(app: tauri::AppHandle, safe_mode: Option<bool>) -> Re
     }
     Ok("ok".into())
   } else {
+    // local_speak_blocking is blocking — run on dedicated thread
     #[cfg(target_os = "windows")]
     {
       let voice = settings.get("tts_voice_local").and_then(|x| x.as_str()).unwrap_or("").to_string();
-      crate::tts::local_speak_blocking(selection, voice, rate, vol)?;
+      tokio::task::spawn_blocking(move || {
+        crate::tts::local_speak_blocking(selection, voice, rate, vol)
+      }).await.map_err(|e| format!("spawn_blocking failed: {e}"))??;
       Ok("ok".into())
     }
     #[cfg(not(target_os = "windows"))]

--- a/app/src-tauri/src/quick_prompts.rs
+++ b/app/src-tauri/src/quick_prompts.rs
@@ -36,6 +36,7 @@ pub fn quick_prompts_config_path() -> Option<PathBuf> {
 // Uses aggressive copy-restore by default unless safe_mode is true.
 #[tauri::command]
 pub async fn run_quick_prompt(app: tauri::AppHandle, index: u8, safe_mode: Option<bool>) -> Result<(), String> {
+  if index < 1 || index > 9 { return Err("Quick prompt index must be 1-9".into()); }
   let safe = safe_mode.unwrap_or(false);
 
   // Capture selection text (duplication kept for clarity and simplicity)
@@ -164,6 +165,7 @@ pub async fn run_quick_prompt(app: tauri::AppHandle, index: u8, safe_mode: Optio
 /// `run_quick_prompt`.
 #[tauri::command]
 pub async fn run_quick_prompt_result(app: tauri::AppHandle, index: u8, safe_mode: Option<bool>) -> Result<String, String> {
+  if index < 1 || index > 9 { return Err("Quick prompt index must be 1-9".into()); }
   let safe = safe_mode.unwrap_or(false);
 
   // Capture selection text (duplication kept for clarity and simplicity)
@@ -272,6 +274,7 @@ pub async fn run_quick_prompt_result(app: tauri::AppHandle, index: u8, safe_mode
 /// inline preview flows when the frontend has already captured the selection.
 #[tauri::command]
 pub async fn run_quick_prompt_with_selection(app: tauri::AppHandle, index: u8, selection: String) -> Result<String, String> {
+  if index < 1 || index > 9 { return Err("Quick prompt index must be 1-9".into()); }
   // If empty selection, return a friendly message for the preview UI.
   if selection.trim().is_empty() {
     return Ok("No selection. Type your input or paste it here.".to_string());

--- a/app/src-tauri/src/stt.rs
+++ b/app/src-tauri/src/stt.rs
@@ -21,6 +21,7 @@ fn build_transcriptions_url(base_url: &str) -> String {
 /// Transcribe audio bytes using OpenAI Whisper API (expects WEBM/Opus by default).
 /// Returns the transcribed text on success.
 pub async fn transcribe(key: Option<String>, base_url: String, model: String, audio: Vec<u8>, mime: String) -> Result<String, String> {
+  if audio.is_empty() { return Err("Audio data is empty".into()); }
   // Build multipart form: model + file
   let file_name = if mime.contains("webm") { "audio.webm" } else { "audio.bin" };
   let part = reqwest::multipart::Part::bytes(audio)

--- a/app/src-tauri/src/tts_openai.rs
+++ b/app/src-tauri/src/tts_openai.rs
@@ -47,6 +47,8 @@ pub async fn ensure_streaming_server() -> Result<(), String> {
 }
 
 pub async fn create_stream_session(text: String, voice: Option<String>, model: Option<String>, format: Option<String>, instructions: Option<String>, api_key: String) -> Result<String, String> {
+  if text.trim().is_empty() { return Err("Text is empty".into()); }
+  if text.len() > OPENAI_TTS_MAX_INPUT_CHARS { return Err(format!("Text exceeds TTS limit of {} characters", OPENAI_TTS_MAX_INPUT_CHARS)); }
   ensure_streaming_server().await?;
   let guard = TTS_STREAMING_SERVER.lock().map_err(|_| "Mutex poisoned")?;
   let server = guard.as_ref().ok_or_else(|| "TTS streaming server not available".to_string())?;
@@ -88,6 +90,8 @@ pub fn openai_stream_start(
   model: Option<String>,
   format: Option<String>,
 ) -> Result<u64, String> {
+  if text.trim().is_empty() { return Err("Text is empty".into()); }
+  if text.len() > OPENAI_TTS_MAX_INPUT_CHARS { return Err(format!("Text exceeds TTS limit of {} characters", OPENAI_TTS_MAX_INPUT_CHARS)); }
   let fmt = format.unwrap_or_else(|| "opus".to_string());
   let (accept, body_format, mime): (&'static str, &'static str, &'static str) = match fmt.as_str() {
     "mp3" => ("audio/mpeg", "mp3", "audio/mpeg"),
@@ -125,6 +129,8 @@ pub fn responses_stream_start(
   model: Option<String>,
   format: Option<String>,
 ) -> Result<u64, String> {
+  if text.trim().is_empty() { return Err("Text is empty".into()); }
+  if text.len() > OPENAI_TTS_MAX_INPUT_CHARS { return Err(format!("Text exceeds TTS limit of {} characters", OPENAI_TTS_MAX_INPUT_CHARS)); }
   let fmt = format.unwrap_or_else(|| "opus".to_string());
   let req_model = model.unwrap_or_else(|| "gpt-4o-mini-tts".to_string());
   let m = if req_model.contains("tts") { "gpt-4o-realtime-preview".to_string() } else { req_model };

--- a/app/src-tauri/src/tts_win_native.rs
+++ b/app/src-tauri/src/tts_win_native.rs
@@ -14,6 +14,7 @@ static TTS_CHILD: Lazy<Mutex<Option<std::process::Child>>> = Lazy::new(|| Mutex:
 
 #[cfg(target_os = "windows")]
 pub fn local_tts_start(text: String, voice: Option<String>, rate: Option<i32>, volume: Option<u8>) -> Result<(), String> {
+  if text.trim().is_empty() { return Err("Text is empty".into()); }
   if let Ok(mut guard) = TTS_CHILD.lock() {
     if let Some(mut c) = guard.take() { let _ = c.kill(); let _ = c.wait(); }
   }
@@ -144,6 +145,7 @@ pub fn local_speak_blocking(_text: String, _voice: String, _rate: i32, _vol: u8)
 
 #[cfg(target_os = "windows")]
 pub fn local_tts_synthesize_wav(text: String, voice: Option<String>, rate: Option<i32>, volume: Option<u8>) -> Result<String, String> {
+  if text.trim().is_empty() { return Err("Text is empty".into()); }
   let v = voice.unwrap_or_default();
   let v_escaped = ps_escape_single_quoted(&v);
   let r = rate.unwrap_or(-2).clamp(-10, 10);

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -79,6 +79,18 @@ function keyLog(msg: string): void {
   } catch {}
 }
 
+// Dump key log to file via backend (no clipboard conflict)
+async function dumpKeyLogToFile(trigger: string): Promise<void> {
+  const log = sessionStorage.getItem('qa_key_log') || '(empty)'
+  const summary = `[${trigger}]\nsuppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
+  try {
+    const path = await invoke<string>('dump_key_log', { text: summary })
+    keyLog(`LOG DUMPED TO FILE via ${trigger}: ${path}`)
+  } catch (err) {
+    keyLog(`LOG DUMP FAILED: ${err}`)
+  }
+}
+
 async function suppressKeyGlobal(keyChar: string, onRelease?: () => void): Promise<void> {
   const upper = keyChar.toUpperCase()
   if (suppressedKeys.has(upper)) {
@@ -233,14 +245,10 @@ function onKeydown(e: KeyboardEvent): void {
     return
   }
 
-  // Ctrl+L: dump key log to clipboard for debugging (works in ALL modes including recording)
+  // Ctrl+L: dump key log to file for debugging (works in ALL modes including recording)
   if (e.key.toLowerCase() === 'l' && (e.ctrlKey || e.metaKey)) {
     e.preventDefault()
-    const log = sessionStorage.getItem('qa_key_log') || '(empty)'
-    const summary = `suppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
-    invoke('copy_text_to_clipboard', { text: summary }).then(() => {
-      keyLog('LOG DUMPED TO CLIPBOARD via Ctrl+L')
-    }).catch(() => {})
+    void dumpKeyLogToFile('local Ctrl+L')
     return
   }
 
@@ -482,11 +490,7 @@ async function startSTT(): Promise<void> {
     // even when popup has no focus (S is globally captured -> focus stays on prev app)
     try {
       await register('CommandOrControl+L', () => {
-        const log = sessionStorage.getItem('qa_key_log') || '(empty)'
-        const summary = `[GLOBAL Ctrl+L DUMP]\nsuppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
-        invoke('copy_text_to_clipboard', { text: summary }).then(() => {
-          keyLog('LOG DUMPED TO CLIPBOARD via global Ctrl+L')
-        }).catch(() => {})
+        void dumpKeyLogToFile('global Ctrl+L during STT')
       })
       keyLog('registered global Ctrl+L for STT debug dump')
     } catch (err) {

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -233,6 +233,17 @@ function onKeydown(e: KeyboardEvent): void {
     return
   }
 
+  // Ctrl+L: dump key log to clipboard for debugging
+  if (e.key.toLowerCase() === 'l' && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault()
+    const log = sessionStorage.getItem('qa_key_log') || '(empty)'
+    const summary = `suppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
+    invoke('copy_text_to_clipboard', { text: summary }).then(() => {
+      keyLog('LOG DUMPED TO CLIPBOARD via Ctrl+L')
+    }).catch(() => {})
+    return
+  }
+
   // Only react to single keys when this window is focused
   const key = e.key.toLowerCase()
 

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -233,7 +233,7 @@ function onKeydown(e: KeyboardEvent): void {
     return
   }
 
-  // Ctrl+L: dump key log to clipboard for debugging
+  // Ctrl+L: dump key log to clipboard for debugging (works in ALL modes including recording)
   if (e.key.toLowerCase() === 'l' && (e.ctrlKey || e.metaKey)) {
     e.preventDefault()
     const log = sessionStorage.getItem('qa_key_log') || '(empty)'
@@ -478,6 +478,20 @@ async function startSTT(): Promise<void> {
       // On key release via global shortcut (user switched focus while holding S)
       if (sttRecording.value) void stopSTTAndTranscribe()
     })
+    // Register Ctrl+L as global shortcut during recording so user can dump log
+    // even when popup has no focus (S is globally captured -> focus stays on prev app)
+    try {
+      await register('CommandOrControl+L', () => {
+        const log = sessionStorage.getItem('qa_key_log') || '(empty)'
+        const summary = `[GLOBAL Ctrl+L DUMP]\nsuppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
+        invoke('copy_text_to_clipboard', { text: summary }).then(() => {
+          keyLog('LOG DUMPED TO CLIPBOARD via global Ctrl+L')
+        }).catch(() => {})
+      })
+      keyLog('registered global Ctrl+L for STT debug dump')
+    } catch (err) {
+      keyLog(`global Ctrl+L register FAILED: ${err}`)
+    }
     console.info('[stt] recording started')
     // If stop was requested while we were awaiting mic permission, stop now
     if (sttStopRequested.value) {
@@ -502,10 +516,19 @@ async function stopSTTAndTranscribe(): Promise<void> {
     }
     return
   }
-  keyLog('stopSTT begin — eagerly setting recording=false')
+  keyLog('stopSTT begin -- eagerly setting recording=false')
   sttRecording.value = false  // eagerly claim to prevent concurrent entry
-  // Immediately unregister global S-key so it doesn't interfere after recording
+  // Immediately unregister global S-key and Ctrl+L debug shortcut
   await unsuppressKeyGlobal('S')
+  try { await unregister('CommandOrControl+L') } catch {}
+  keyLog('unregistered global Ctrl+L')
+  // Auto-dump key log on every STT stop for diagnostics
+  try {
+    const log = sessionStorage.getItem('qa_key_log') || '(empty)'
+    const summary = `[AUTO-DUMP stopSTT]\nsuppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
+    await invoke('copy_text_to_clipboard', { text: summary })
+    keyLog('AUTO-DUMP to clipboard on STT stop')
+  } catch {}
   try {
     const res = await sttStop()
     sttRecording.value = false
@@ -590,6 +613,7 @@ async function stopSTTAndTranscribe(): Promise<void> {
 async function cancelSTT(): Promise<void> {
   keyLog('cancelSTT')
   await unsuppressKeyGlobal('S')
+  try { await unregister('CommandOrControl+L') } catch {}
   try {
     if (sttIsRecording()) await sttStop()
   } catch {}
@@ -607,10 +631,12 @@ onMounted(() => {
   // Clean up any stale global shortcuts from a previous window load/crash.
   // The OS keeps them registered even if our JS state was lost on reload.
   const keysToClean = ['S', 'P', 'T', 'I', '1', '2', '3', '4', '5', '6', '7', '8', '9']
-  keyLog(`mount cleanup — unregistering stale keys: [${keysToClean.join(',')}]`)
+  keyLog(`mount cleanup -- unregistering stale keys: [${keysToClean.join(',')}]`)
   for (const k of keysToClean) {
     unregister(k).catch(() => {})
   }
+  // Also clean up Ctrl+L debug shortcut in case it was left from a crash
+  unregister('CommandOrControl+L').catch(() => {})
 
   // Fit window to content — only resize when size actually changes to avoid loops
   try {

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -522,13 +522,6 @@ async function stopSTTAndTranscribe(): Promise<void> {
   await unsuppressKeyGlobal('S')
   try { await unregister('CommandOrControl+L') } catch {}
   keyLog('unregistered global Ctrl+L')
-  // Auto-dump key log on every STT stop for diagnostics
-  try {
-    const log = sessionStorage.getItem('qa_key_log') || '(empty)'
-    const summary = `[AUTO-DUMP stopSTT]\nsuppressedKeys: [${[...suppressedKeys].join(',')}]\nsttRecording: ${sttRecording.value}\nsttPending: ${sttPending.value}\nuiMode: ${uiMode.value}\n\n${log}`
-    await invoke('copy_text_to_clipboard', { text: summary })
-    keyLog('AUTO-DUMP to clipboard on STT stop')
-  } catch {}
   try {
     const res = await sttStop()
     sttRecording.value = false

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -555,6 +555,13 @@ onMounted(() => {
   window.addEventListener('focus', onWindowFocus)
   window.addEventListener('mouseup', onWindowMouseup)
 
+  // Clean up any stale global shortcuts from a previous window load/crash.
+  // The OS keeps them registered even if our JS state was lost on reload.
+  const keysToClean = ['S', 'P', 'T', 'I', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+  for (const k of keysToClean) {
+    unregister(k).catch(() => {})
+  }
+
   // Fit window to content — only resize when size actually changes to avoid loops
   try {
     const el = rootRef.value

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -247,8 +247,8 @@ function onKeydown(e: KeyboardEvent): void {
     }
     return
   }
-  // Number keys 1–9: only in home mode and not during STT recording; action fires on keyup
-  if (uiMode.value === 'home' && !sttRecording.value && !sttPending.value && key >= '1' && key <= '9') {
+  // Number keys 1–9: active in home and info mode (not during STT recording); action fires on keyup
+  if ((uiMode.value === 'home' || uiMode.value === 'info') && !sttRecording.value && !sttPending.value && key >= '1' && key <= '9') {
     e.preventDefault()
     if (e.repeat) return  // skip key repeats
     const numKey = key
@@ -295,13 +295,15 @@ function onKeyup(e: KeyboardEvent): void {
     if (key === 'c' && !previewBusy.value && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); void onCopy(); return }
     if (key === 'v' && !previewBusy.value && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); void onInsert(); return }
   }
-  // Number keys 1–9 trigger quick prompts on keyup (only in home mode, not during STT recording)
+  // Number keys 1–9 trigger quick prompts on keyup (home and info mode, not during STT recording)
   if (key >= '1' && key <= '9') {
     e.preventDefault()
     void unsuppressKeyGlobal(key)
-    if (uiMode.value !== 'home') return
+    if (uiMode.value !== 'home' && uiMode.value !== 'info') return
     // During STT recording, number keys are for post-processing selection (handled in keydown) — don't fire quick prompt
     if (sttRecording.value || sttPending.value) return
+    // Switch back to home if in info mode
+    if (uiMode.value === 'info') uiMode.value = 'home'
     const index = Number(key)
     dbg('number key released', index, { showPreviewInPopup: showPreviewInPopup.value })
     if (showPreviewInPopup.value) {
@@ -779,7 +781,7 @@ async function onInsert(): Promise<void> {
             </span>
           </div>
         </div>
-        <div class="qa-hint">Press a number key to run. Hold S + number for STT with post-processing.</div>
+        <div class="qa-hint">Press 1–9 to run. Hold S + number for STT with post-processing. Esc to go back.</div>
       </div>
     </template>
 

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -299,7 +299,7 @@ function onKeydown(e: KeyboardEvent): void {
     return
   }
   // Number keys 1–9: active in home and info mode (not during STT recording); action fires on keyup
-  if ((uiMode.value === 'home' || uiMode.value === 'info') && !sttRecording.value && !sttPending.value && key >= '1' && key <= '9') {
+  if ((uiMode.value === 'home' || uiMode.value === 'info') && !sttRecording.value && !sttPending.value && !previewBusy.value && key >= '1' && key <= '9') {
     e.preventDefault()
     if (e.repeat) return  // skip key repeats
     const numKey = key
@@ -349,10 +349,14 @@ function onKeyup(e: KeyboardEvent): void {
   // Number keys 1–9 trigger quick prompts on keyup (home and info mode, not during STT recording)
   if (key >= '1' && key <= '9') {
     e.preventDefault()
+    // If key was already unsuppressed by the global callback, skip to prevent double-fire
+    if (!suppressedKeys.has(key)) return
     void unsuppressKeyGlobal(key)
     if (uiMode.value !== 'home' && uiMode.value !== 'info') return
     // During STT recording, number keys are for post-processing selection (handled in keydown) — don't fire quick prompt
     if (sttRecording.value || sttPending.value) return
+    // Prevent concurrent invocations
+    if (previewBusy.value) return
     // Switch back to home if in info mode
     if (uiMode.value === 'info') uiMode.value = 'home'
     const index = Number(key)
@@ -765,11 +769,12 @@ onBeforeUnmount(() => {
   try { if (unlistenBlur) unlistenBlur() } catch {}
   try { if (unlistenFocus) unlistenFocus() } catch {}
   try { if (unlistenHide) unlistenHide() } catch {}
-  try { if (resizeObserver) resizeObserver.disconnect() } catch {}
+  try { if (resizeObserver) { resizeObserver.disconnect(); resizeObserver = null } } catch {}
   if (blurCloseTimer) { clearTimeout(blurCloseTimer); blurCloseTimer = null }
-  // Clean up all global key suppressions
-  keyLog('onBeforeUnmount — cleaning up')
+  // Clean up all global key suppressions + Ctrl+L debug shortcut
+  keyLog('onBeforeUnmount -- cleaning up')
   void unsuppressAllKeys()
+  unregister('CommandOrControl+L').catch(() => {})
 })
 
 // Copy preview result to clipboard and close popup

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -62,34 +62,66 @@ const allowPreviewHotkeys = true
 // Registers a global shortcut for a key so it doesn't leak into other apps,
 // then auto-unregisters on keyup (via the global shortcut callback).
 const suppressedKeys = new Set<string>()
+
+// Persistent key-suppression log for debugging stuck-key issues.
+// Viewable via sessionStorage.getItem('qa_key_log') in DevTools.
+function keyLog(msg: string): void {
+  const ts = new Date().toISOString().slice(11, 23)
+  const line = `[${ts}] ${msg}`
+  console.info('[QA-keys]', msg)
+  try {
+    const prev = sessionStorage.getItem('qa_key_log') || ''
+    // Keep last 80 lines to avoid unbounded growth
+    const lines = prev ? prev.split('\n') : []
+    lines.push(line)
+    if (lines.length > 80) lines.splice(0, lines.length - 80)
+    sessionStorage.setItem('qa_key_log', lines.join('\n'))
+  } catch {}
+}
+
 async function suppressKeyGlobal(keyChar: string, onRelease?: () => void): Promise<void> {
   const upper = keyChar.toUpperCase()
-  if (suppressedKeys.has(upper)) return
+  if (suppressedKeys.has(upper)) {
+    keyLog(`suppress(${upper}) SKIP — already in Set`)
+    return
+  }
   try {
+    keyLog(`suppress(${upper}) registering...`)
     await register(upper, (event) => {
+      keyLog(`global-callback(${upper}) state=${event.state}`)
       if (event.state === 'Released') {
         void unsuppressKeyGlobal(upper)
         onRelease?.()
       }
     })
     suppressedKeys.add(upper)
-    dbg(`global suppress registered: ${upper}`)
-  } catch {
-    // Best-effort; if it fails the key just leaks through
+    keyLog(`suppress(${upper}) OK — Set: [${[...suppressedKeys].join(',')}]`)
+  } catch (err) {
+    keyLog(`suppress(${upper}) FAILED: ${err}`)
   }
 }
 async function unsuppressKeyGlobal(keyChar: string): Promise<void> {
   const upper = keyChar.toUpperCase()
-  if (!suppressedKeys.has(upper)) return
+  if (!suppressedKeys.has(upper)) {
+    keyLog(`unsuppress(${upper}) SKIP — not in Set`)
+    return
+  }
   try {
+    keyLog(`unsuppress(${upper}) unregistering...`)
     await unregister(upper)
-  } catch {}
-  suppressedKeys.delete(upper)  // always clean up tracking regardless of unregister success
+    keyLog(`unsuppress(${upper}) OK`)
+  } catch (err) {
+    keyLog(`unsuppress(${upper}) unregister FAILED: ${err}`)
+  }
+  suppressedKeys.delete(upper)
+  keyLog(`unsuppress(${upper}) Set after: [${[...suppressedKeys].join(',')}]`)
 }
 async function unsuppressAllKeys(): Promise<void> {
+  keyLog(`unsuppressAll — Set: [${[...suppressedKeys].join(',')}]`)
   for (const k of [...suppressedKeys]) {
     await unsuppressKeyGlobal(k)
   }
+  keyLog(`unsuppressAll done — Set: [${[...suppressedKeys].join(',')}]`)
 }
 
 function clearPreviewState(): void {
@@ -419,7 +451,11 @@ function onWindowMouseup(): void {
 }
 
 async function startSTT(): Promise<void> {
-  if (sttRecording.value || sttIsRecording() || sttPending.value) return
+  if (sttRecording.value || sttIsRecording() || sttPending.value) {
+    keyLog(`startSTT SKIP — recording=${sttRecording.value} isRecording=${sttIsRecording()} pending=${sttPending.value}`)
+    return
+  }
+  keyLog('startSTT begin')
   try {
     sttPending.value = true
     sttStopRequested.value = false
@@ -449,12 +485,13 @@ async function startSTT(): Promise<void> {
 
 async function stopSTTAndTranscribe(): Promise<void> {
   if (!sttRecording.value) {
-    // If we're still pending (mic permission), flag for deferred stop
+    keyLog(`stopSTT SKIP — recording=false, pending=${sttPending.value}`)
     if (sttPending.value) {
       sttStopRequested.value = true
     }
     return
   }
+  keyLog('stopSTT begin — eagerly setting recording=false')
   sttRecording.value = false  // eagerly claim to prevent concurrent entry
   // Immediately unregister global S-key so it doesn't interfere after recording
   await unsuppressKeyGlobal('S')
@@ -540,6 +577,7 @@ async function stopSTTAndTranscribe(): Promise<void> {
 }
 
 async function cancelSTT(): Promise<void> {
+  keyLog('cancelSTT')
   await unsuppressKeyGlobal('S')
   try {
     if (sttIsRecording()) await sttStop()
@@ -558,6 +596,7 @@ onMounted(() => {
   // Clean up any stale global shortcuts from a previous window load/crash.
   // The OS keeps them registered even if our JS state was lost on reload.
   const keysToClean = ['S', 'P', 'T', 'I', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+  keyLog(`mount cleanup — unregistering stale keys: [${keysToClean.join(',')}]`)
   for (const k of keysToClean) {
     unregister(k).catch(() => {})
   }
@@ -695,6 +734,7 @@ onBeforeUnmount(() => {
   try { if (resizeObserver) resizeObserver.disconnect() } catch {}
   if (blurCloseTimer) { clearTimeout(blurCloseTimer); blurCloseTimer = null }
   // Clean up all global key suppressions
+  keyLog('onBeforeUnmount — cleaning up')
   void unsuppressAllKeys()
 })
 

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -247,8 +247,8 @@ function onKeydown(e: KeyboardEvent): void {
     }
     return
   }
-  // Number keys 1–9: only in home mode; action fires on keyup
-  if (uiMode.value === 'home' && key >= '1' && key <= '9') {
+  // Number keys 1–9: only in home mode and not during STT recording; action fires on keyup
+  if (uiMode.value === 'home' && !sttRecording.value && !sttPending.value && key >= '1' && key <= '9') {
     e.preventDefault()
     if (e.repeat) return  // skip key repeats
     const numKey = key
@@ -295,11 +295,13 @@ function onKeyup(e: KeyboardEvent): void {
     if (key === 'c' && !previewBusy.value && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); void onCopy(); return }
     if (key === 'v' && !previewBusy.value && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); void onInsert(); return }
   }
-  // Number keys 1–9 trigger quick prompts on keyup (only in home mode)
+  // Number keys 1–9 trigger quick prompts on keyup (only in home mode, not during STT recording)
   if (key >= '1' && key <= '9') {
     e.preventDefault()
     void unsuppressKeyGlobal(key)
     if (uiMode.value !== 'home') return
+    // During STT recording, number keys are for post-processing selection (handled in keydown) — don't fire quick prompt
+    if (sttRecording.value || sttPending.value) return
     const index = Number(key)
     dbg('number key released', index, { showPreviewInPopup: showPreviewInPopup.value })
     if (showPreviewInPopup.value) {


### PR DESCRIPTION
## Changes since PR #10 merge

### Key Suppression Logging (build18-20)
- Persistent key-suppression log in sessionStorage + console.info for every suppress/unsuppress event
- Ctrl+L dumps log to file (%APPDATA%/AiDesktopCompanion/qa_key_log.txt)  works during STT recording via global shortcut
- Stale shortcut cleanup on mount (S/P/T/I/1-9 + Ctrl+L)

### Bug Hunting Rounds 8-10 (build21-22, 13 fixes)
**Backend:**
- dump_key_log: cross-platform support (HOME fallback) + 1MB rotation
- tts_win_native: reject empty text in local_tts_start/synthesize_wav
- stt.rs: reject empty audio bytes before API call
- quick_prompts: validate index 1-9 in all three run_quick_prompt variants
- mcp.rs: FN_REVERSE_MAP atomic swap (build new map then replace) prevents stale routing + TOCTOU race
- tts_selection: spawn_blocking for clipboard/enigo/sleep + local_speak_blocking  prevents async runtime starvation
- tts_openai: empty-text + length validation for streaming functions

**Frontend (QuickActions.vue):**
- Ctrl+L global shortcut deregistered in onBeforeUnmount
- ResizeObserver properly disconnected on unmount
- Number key busy guard prevents concurrent quick prompt invocations
- Number key double-fire prevention (check suppressedKeys before action)

### Review Results
- 10 rounds with 10 virtual subagents each
- Round 10: all subagent groups report CLEAN
- 0 regressions detected
- Build22 deployed and running