### PR TITLE
feat(app): Claude Code voice integration assessment and Assistant Mode call fixes

### DIFF
--- a/app/src-tauri/src/assistant_pill.rs
+++ b/app/src-tauri/src/assistant_pill.rs
@@ -37,11 +37,15 @@ pub struct PillState {
   /// Configured push-to-talk shortcut, shown in the armed prompt so the user is
   /// told which key to press again rather than having to remember.
   pub hotkey: String,
+  /// Whether the session is in push-to-talk. The pill offers a hold-to-talk
+  /// button only when it would do something - in open-mic mode the microphone
+  /// is already live and the button would be dead.
+  pub ptt: bool,
 }
 
 impl Default for PillState {
   fn default() -> Self {
-    Self { state: "hidden".into(), started_ms: 0, mic_open: false, hotkey: String::new() }
+    Self { state: "hidden".into(), started_ms: 0, mic_open: false, hotkey: String::new(), ptt: false }
   }
 }
 
@@ -111,6 +115,7 @@ pub fn assistant_pill_set(
   state: String,
   mic_open: Option<bool>,
   hotkey: Option<String>,
+  ptt: Option<bool>,
 ) -> Result<(), String> {
   let wanted = match state.as_str() {
     "armed" => "armed",
@@ -132,6 +137,7 @@ pub fn assistant_pill_set(
       started_ms,
       mic_open: mic_open.unwrap_or(false),
       hotkey: hotkey.unwrap_or_default(),
+      ptt: ptt.unwrap_or(false),
     };
     cur.clone()
   };

--- a/app/src-tauri/src/assistant_pill.rs
+++ b/app/src-tauri/src/assistant_pill.rs
@@ -5,12 +5,15 @@
 //! Without something on screen there is no way to tell a live call from a closed
 //! one, and no way to hang up without hunting for the window.
 //!
-//! Two states are shown:
-//!   * `armed` - the push-to-talk key was pressed with no session running, so the
-//!     pill invites a second press to start the call. Starting a call costs
+//! Three states are shown:
+//!   * `armed`   - the push-to-talk key was pressed with no session running, so
+//!     the pill invites a second press to start the call. Starting a call costs
 //!     money and turns on a microphone; neither should happen on a single
 //!     stray keypress.
-//!   * `live`  - a call is up. The pill reports it and offers a hang-up button.
+//!   * `calling` - the session is being set up. A token, an SDP exchange and ICE
+//!     take a second or two, and without this the pill only appeared once the
+//!     call was already up, so the wait looked like nothing happening.
+//!   * `live`    - a call is up. The pill reports it and offers a hang-up button.
 //!
 //! The window is declared statically in `tauri.conf.json` (label
 //! `assistant-pill`) so it never has to be created on the hot path, and it
@@ -27,7 +30,7 @@ pub const PILL_WINDOW_LABEL: &str = "assistant-pill";
 
 #[derive(Clone, Debug, Serialize)]
 pub struct PillState {
-  /// "hidden" | "armed" | "live"
+  /// "hidden" | "armed" | "calling" | "live"
   pub state: String,
   /// Epoch milliseconds the call connected, so the pill can render an elapsed
   /// counter even if the window mounts late. Zero unless live.
@@ -106,7 +109,7 @@ fn publish(app: &tauri::AppHandle, state: &PillState) {
 
 /// Drive the pill from the frontend.
 ///
-/// `state` is "hidden", "armed" or "live". Anything else is treated as hidden
+/// `state` is "hidden", "armed", "calling" or "live". Anything else is hidden
 /// rather than rejected: a pill that refuses to disappear is worse than one that
 /// disappears when it should not.
 #[tauri::command]
@@ -119,6 +122,7 @@ pub fn assistant_pill_set(
 ) -> Result<(), String> {
   let wanted = match state.as_str() {
     "armed" => "armed",
+    "calling" => "calling",
     "live" => "live",
     _ => "hidden",
   };
@@ -173,14 +177,34 @@ mod tests {
   fn unknown_states_hide_rather_than_error() {
     // A pill stuck on screen is worse than one that hides when it should not,
     // so anything unrecognised collapses to hidden.
-    for input in ["", "LIVE", "connecting", "garbage"] {
+    // "connecting" is in here deliberately: the accepted spelling is "calling",
+    // and a near miss has to collapse like any other unknown value.
+    for input in ["", "LIVE", "connecting", "Calling", "garbage"] {
       let mapped = match input {
         "armed" => "armed",
+        "calling" => "calling",
         "live" => "live",
         _ => "hidden",
       };
       assert_eq!(mapped, "hidden", "unexpected mapping for {input:?}");
     }
+  }
+
+  #[test]
+  fn calling_is_accepted_and_carries_no_timer() {
+    // The elapsed counter belongs to a connected call; a pill that starts
+    // counting while still dialling would report the wrong duration.
+    for input in ["armed", "calling", "live"] {
+      let mapped = match input {
+        "armed" => "armed",
+        "calling" => "calling",
+        "live" => "live",
+        _ => "hidden",
+      };
+      assert_eq!(mapped, input, "{input:?} should be accepted as itself");
+    }
+    let started_for_calling = if "calling" == "live" { 1 } else { 0 };
+    assert_eq!(started_for_calling, 0);
   }
 
   #[test]

--- a/app/src-tauri/src/mcp.rs
+++ b/app/src-tauri/src/mcp.rs
@@ -40,6 +40,35 @@ pub fn resolve_windows_program(prog: &str, cwd: Option<&str>) -> Option<String> 
   None
 }
 
+/// Publish a freshly-connected client, yielding to a concurrent connect rather
+/// than displacing it.
+///
+/// The "already connected" check at the top of `connect` releases the map lock
+/// before the child is spawned, so two calls for the same server can both get
+/// past it - which happens in practice, and was observed spawning two copies of
+/// a stdio server 23ms apart. Whoever arrived second used to overwrite the first
+/// entry, and because dropping a `RunningService` does not stop it (`disconnect`
+/// cancels explicitly for exactly that reason) the displaced client stayed alive
+/// as an orphan process nothing could reach or shut down. For a server that
+/// fronts stateful work - a session, a queue, a lane - two of them is worse than
+/// none.
+///
+/// Returns false when another client won the race and this one was cancelled.
+async fn publish_or_yield(
+  clients: &AsyncMutex<ClientMap>,
+  server_id: &str,
+  service: Arc<RunningService<RoleClient, ()>>,
+) -> bool {
+  let mut map = clients.lock().await;
+  if map.contains_key(server_id) {
+    drop(map);
+    service.cancellation_token().cancel();
+    return false;
+  }
+  map.insert(server_id.to_string(), service);
+  true
+}
+
 pub async fn connect(
   app: &tauri::AppHandle,
   clients: &AsyncMutex<ClientMap>,
@@ -69,9 +98,8 @@ pub async fn connect(
       msg
     })?;
     let service = Arc::new(service);
-    {
-      let mut map = clients.lock().await;
-      map.insert(server_id.clone(), service.clone());
+    if !publish_or_yield(clients, &server_id, service).await {
+      return Ok("already connected".into());
     }
     let _ = app.emit("mcp:connected", serde_json::json!({ "serverId": server_id }));
     return Ok("connected".into());
@@ -113,9 +141,8 @@ pub async fn connect(
     msg
   })?;
   let service = Arc::new(service);
-  {
-    let mut map = clients.lock().await;
-    map.insert(server_id.clone(), service.clone());
+  if !publish_or_yield(clients, &server_id, service).await {
+    return Ok("already connected".into());
   }
   let _ = app.emit("mcp:connected", serde_json::json!({ "serverId": server_id }));
   Ok("connected".into())

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
         "label": "assistant-pill",
         "title": "Assistant call",
         "url": "/?window=assistant-pill",
-        "width": 320,
+        "width": 380,
         "height": 60,
         "resizable": false,
         "decorations": false,

--- a/app/src/components/AssistantPill.vue
+++ b/app/src/components/AssistantPill.vue
@@ -17,7 +17,7 @@ import { emit, listen } from '@tauri-apps/api/event'
 import type { UnlistenFn } from '@tauri-apps/api/event'
 
 type PillState = {
-  state: 'hidden' | 'armed' | 'live'
+  state: 'hidden' | 'armed' | 'calling' | 'live'
   started_ms: number
   mic_open: boolean
   hotkey: string
@@ -25,7 +25,17 @@ type PillState = {
 }
 
 const state = ref<PillState>({ state: 'hidden', started_ms: 0, mic_open: false, hotkey: '', ptt: false })
+/** Whether this window's own pointer is down on the button. */
 const holding = ref(false)
+
+/**
+ * Whether the microphone is open, however it was opened.
+ *
+ * The button is not the only way to talk - the global hotkey is the main one -
+ * so its appearance follows `mic_open` from the backend rather than this
+ * window's own pointer state. Holding the hotkey now lights the button too.
+ */
+const talking = computed(() => state.value.mic_open || holding.value)
 const nowMs = ref<number>(Date.now())
 
 let ticker: number | null = null
@@ -114,6 +124,15 @@ onBeforeUnmount(() => {
       </span>
     </template>
 
+    <template v-else-if="state.state === 'calling'">
+      <span class="ring" aria-hidden="true"></span>
+      <span class="text">
+        <strong>Calling</strong>
+        <span class="dots" aria-hidden="true"><i></i><i></i><i></i></span>
+      </span>
+      <button class="btn hangup" type="button" title="Cancel the call" @click="hangUp">Cancel</button>
+    </template>
+
     <template v-else-if="state.state === 'live'">
       <span class="dot" :class="{ open: state.mic_open }" aria-hidden="true"></span>
       <span class="text">
@@ -122,16 +141,16 @@ onBeforeUnmount(() => {
       </span>
       <button
         v-if="state.ptt"
-        class="talk"
-        :class="{ holding }"
+        class="btn talk"
+        :class="{ talking }"
         type="button"
-        title="Hold to talk"
+        :title="state.hotkey ? `Hold to talk (or hold ${state.hotkey})` : 'Hold to talk'"
         @pointerdown="pttDown"
         @pointerup="pttUp"
         @pointercancel="pttUp"
         @lostpointercapture="pttUp"
-      >{{ holding ? 'Release' : 'Hold' }}</button>
-      <button class="hangup" type="button" title="End the call" @click="hangUp">End</button>
+      >{{ talking ? 'Talking' : 'Talk' }}</button>
+      <button class="btn hangup" type="button" title="End the call" @click="hangUp">End</button>
     </template>
   </div>
 </template>
@@ -158,6 +177,7 @@ onBeforeUnmount(() => {
   overflow: hidden;
 }
 .pill.armed { border-color: rgba(122, 162, 255, 0.5); }
+.pill.calling { border-color: rgba(122, 162, 255, 0.5); }
 .pill.live { border-color: rgba(90, 200, 130, 0.45); }
 
 .glyph { font-size: 14px; flex: 0 0 auto; }
@@ -197,35 +217,78 @@ code {
   box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.2);
 }
 
-/* Green while held, matching the mic dot, so the state is readable from the
-   corner of the eye without reading the label. */
-.talk {
+/* One button shape for the pill, so Talk and End read as a pair rather than as
+   two unrelated controls. Only the accent colour differs. */
+.btn {
   flex: 0 0 auto;
-  border: 1px solid rgba(120, 200, 150, 0.45);
-  background: rgba(60, 180, 110, 0.18);
-  color: #b6f0cd;
   border-radius: 999px;
   padding: 3px 12px;
   font-size: 11.5px;
+  line-height: 1.4;
   cursor: pointer;
-  touch-action: none;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: #e8eaf0;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
 }
-.talk:hover { background: rgba(60, 180, 110, 0.3); }
-.talk.holding {
-  background: rgba(74, 222, 128, 0.55);
-  border-color: rgba(74, 222, 128, 0.8);
-  color: #06210f;
+.btn:hover { background: rgba(255, 255, 255, 0.14); }
+
+/* Neutral at rest so it sits with the rest of the pill, and only takes the
+   microphone's green while actually talking - the one moment it matters. */
+.talk { touch-action: none; }
+.talk.talking {
+  background: rgba(74, 222, 128, 0.22);
+  border-color: rgba(74, 222, 128, 0.55);
+  color: #a7f3c4;
 }
 
-.hangup {
-  flex: 0 0 auto;
-  border: 1px solid rgba(255, 120, 120, 0.45);
-  background: rgba(220, 60, 60, 0.22);
-  color: #ffb4b4;
-  border-radius: 999px;
-  padding: 3px 12px;
-  font-size: 11.5px;
-  cursor: pointer;
+.hangup { color: #f0b8b8; border-color: rgba(255, 255, 255, 0.16); }
+.hangup:hover {
+  background: rgba(220, 60, 60, 0.32);
+  border-color: rgba(255, 120, 120, 0.5);
+  color: #fff;
 }
-.hangup:hover { background: rgba(220, 60, 60, 0.38); color: #fff; }
+
+/* Calling: a ring that pulses outward, and three dots that cycle. Motion is the
+   point - it says "working on it" without the pill having to say so. */
+.ring {
+  position: relative;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #7aa2ff;
+  flex: 0 0 auto;
+}
+.ring::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 1px solid rgba(122, 162, 255, 0.7);
+  animation: ring-pulse 1.4s ease-out infinite;
+}
+@keyframes ring-pulse {
+  0% { transform: scale(0.6); opacity: 0.9; }
+  100% { transform: scale(1.6); opacity: 0; }
+}
+
+.dots { display: inline-flex; gap: 3px; align-items: center; }
+.dots i {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: #9aa3b2;
+  animation: dot-fade 1.2s ease-in-out infinite;
+}
+.dots i:nth-child(2) { animation-delay: 0.15s; }
+.dots i:nth-child(3) { animation-delay: 0.3s; }
+@keyframes dot-fade {
+  0%, 60%, 100% { opacity: 0.25; }
+  30% { opacity: 1; }
+}
+
+/* Motion is decoration here; the words already carry the state. */
+@media (prefers-reduced-motion: reduce) {
+  .ring::after, .dots i { animation: none; }
+}
 </style>

--- a/app/src/components/AssistantPill.vue
+++ b/app/src/components/AssistantPill.vue
@@ -21,9 +21,11 @@ type PillState = {
   started_ms: number
   mic_open: boolean
   hotkey: string
+  ptt: boolean
 }
 
-const state = ref<PillState>({ state: 'hidden', started_ms: 0, mic_open: false, hotkey: '' })
+const state = ref<PillState>({ state: 'hidden', started_ms: 0, mic_open: false, hotkey: '', ptt: false })
+const holding = ref(false)
 const nowMs = ref<number>(Date.now())
 
 let ticker: number | null = null
@@ -53,6 +55,32 @@ function apply(next: PillState) {
 function hangUp() {
   // The session lives in the main window; this only asks for it to end.
   void emit('assistant:hangup')
+}
+
+/**
+ * Hold-to-talk, for when the keyboard shortcut is not to hand.
+ *
+ * The pointer is captured so that releasing anywhere - having slid off the
+ * button, or off the window entirely - still ends the turn. A hold that never
+ * gets its release would leave the microphone open, which is the one failure
+ * push-to-talk exists to prevent.
+ *
+ * `preventDefault` on pointerdown stops the button taking focus. The window is
+ * already non-activating, and a call is meant to be used while working in
+ * another application.
+ */
+function pttDown(e: PointerEvent) {
+  if (holding.value) return
+  e.preventDefault()
+  holding.value = true
+  try { (e.currentTarget as HTMLElement)?.setPointerCapture?.(e.pointerId) } catch {}
+  void emit('assistant:ptt-down')
+}
+
+function pttUp() {
+  if (!holding.value) return
+  holding.value = false
+  void emit('assistant:ptt-up')
 }
 
 onMounted(async () => {
@@ -92,6 +120,17 @@ onBeforeUnmount(() => {
         <strong>{{ state.mic_open ? 'Listening' : 'On call' }}</strong>
         <span class="time">{{ elapsed }}</span>
       </span>
+      <button
+        v-if="state.ptt"
+        class="talk"
+        :class="{ holding }"
+        type="button"
+        title="Hold to talk"
+        @pointerdown="pttDown"
+        @pointerup="pttUp"
+        @pointercancel="pttUp"
+        @lostpointercapture="pttUp"
+      >{{ holding ? 'Release' : 'Hold' }}</button>
       <button class="hangup" type="button" title="End the call" @click="hangUp">End</button>
     </template>
   </div>
@@ -156,6 +195,26 @@ code {
 .dot.open {
   background: #4ade80;
   box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.2);
+}
+
+/* Green while held, matching the mic dot, so the state is readable from the
+   corner of the eye without reading the label. */
+.talk {
+  flex: 0 0 auto;
+  border: 1px solid rgba(120, 200, 150, 0.45);
+  background: rgba(60, 180, 110, 0.18);
+  color: #b6f0cd;
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-size: 11.5px;
+  cursor: pointer;
+  touch-action: none;
+}
+.talk:hover { background: rgba(60, 180, 110, 0.3); }
+.talk.holding {
+  background: rgba(74, 222, 128, 0.55);
+  border-color: rgba(74, 222, 128, 0.8);
+  color: #06210f;
 }
 
 .hangup {

--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onBeforeUnmount, reactive, ref, watch, nextTick } 
 import { invoke } from '@tauri-apps/api/core'
 import { useAssistantRealtime } from '../../composables/useAssistantRealtime'
 import { useSettings } from '../../composables/useSettings'
+import { useCallTones } from '../../composables/useCallTones'
 import CollapsibleCard from '../ui/CollapsibleCard.vue'
 import { listen } from '@tauri-apps/api/event'
 import type { UnlistenFn } from '@tauri-apps/api/event'
@@ -70,7 +71,7 @@ const armed = ref(false)
 let armTimer: any = 0
 
 /** Push the current call state to the floating pill. */
-function syncPill(state: 'hidden' | 'armed' | 'live') {
+function syncPill(state: 'hidden' | 'armed' | 'calling' | 'live') {
   void invoke('assistant_pill_set', {
     state,
     micOpen: state === 'live' ? micEnabled.value : false,
@@ -289,6 +290,10 @@ const session = reactive({
   // A live session bills per minute with an open microphone, so a forgotten
   // window closes itself rather than running until somebody notices.
   autoCloseMinutes: 2,
+  // Ringback while connecting and a beep when the call is up. On by default:
+  // the connect happens from a global hotkey with the window usually hidden, so
+  // sound is the only feedback that reaches the user.
+  callTones: true,
 })
 
 /**
@@ -328,6 +333,8 @@ watch(() => session.micMode, () => { if (ui.connected) syncPill('live') })
 // Load Prompt section settings (temperature, etc.) for supervisor alignment
 const { settings: appSettings, loadSettings } = useSettings()
 
+const tones = useCallTones()
+
 const realtime = useAssistantRealtime({
   getEphemeralToken: async () => {
     try {
@@ -341,9 +348,11 @@ const realtime = useAssistantRealtime({
       throw new Error('Could not mint a realtime token: ' + msg)
     }
   },
-  onConnected: () => { ui.connected = true; ui.connecting = false; ui.error = null; statusText.value = 'Connected'; startElapsed(); syncPill('live') },
-  onDisconnected: () => { ui.connected = false; ui.connecting = false; statusText.value = 'Idle'; stopElapsed(); syncPill('hidden') },
-  onError: (err: string) => { ui.error = err; props.notify?.(err, 'error'); ui.connecting = false; ui.connected = false; statusText.value = 'Error'; try { debugLines.value.push(`[error] ${err}`) } catch {} },
+  onConnected: () => { ui.connected = true; ui.connecting = false; ui.error = null; statusText.value = 'Connected'; startElapsed(); syncPill('live'); tones.stopRingback(); if (session.callTones) tones.readyBeep() },
+  onDisconnected: () => { ui.connected = false; ui.connecting = false; statusText.value = 'Idle'; stopElapsed(); syncPill('hidden'); tones.stopRingback() },
+  // Ringing on past a failed connect would be a phone that never stops, so the
+  // tone is stopped here as well as on the two success paths.
+  onError: (err: string) => { ui.error = err; props.notify?.(err, 'error'); ui.connecting = false; ui.connected = false; statusText.value = 'Error'; tones.stopRingback(); syncPill('hidden'); try { debugLines.value.push(`[error] ${err}`) } catch {} },
   // Surfaced but does not change connection state: the call is still up.
   // A rejected session.update leaves the audio call up but discards every
   // setting in it, tools included. Surfacing that only as a transient toast
@@ -377,6 +386,12 @@ async function activate() {
   } catch {}
   ui.connecting = true
   statusText.value = 'Connecting…'
+  // Before the await, not after: a token, an SDP exchange and ICE take a second
+  // or two, and the pill used to appear only once all of that had succeeded -
+  // so the wait, which is exactly when the user needs to be told something is
+  // happening, was the one moment nothing was shown.
+  syncPill('calling')
+  if (session.callTones) tones.startRingback()
   await realtime.connect({
     enableTools: ui.enableTools,
     useSupervisor: ui.useSupervisor,
@@ -425,6 +440,7 @@ onMounted(async () => {
       if (ar.reasoning_effort === null || REASONING_EFFORTS.includes(ar.reasoning_effort)) session.reasoningEffort = ar.reasoning_effort ?? null
       if (typeof ar.auto_close_minutes === 'number' && ar.auto_close_minutes >= 0) session.autoCloseMinutes = ar.auto_close_minutes
       if (ar.mic_mode === 'open' || ar.mic_mode === 'ptt') session.micMode = ar.mic_mode
+      if (typeof ar.call_tones === 'boolean') session.callTones = ar.call_tones
       if (typeof ar.show_debug === 'boolean') ui.showDebug = ar.show_debug
       // Without these the voice session came up with an empty tool list on every
       // app start, and the only symptom was the model saying it had no tools.
@@ -468,6 +484,7 @@ watch([session, () => ui.enableTools, () => ui.useSupervisor, () => ui.showDebug
           reasoning_effort: session.reasoningEffort,
           auto_close_minutes: session.autoCloseMinutes,
           mic_mode: session.micMode,
+          call_tones: session.callTones,
           show_debug: ui.showDebug,
         }
       }
@@ -511,6 +528,7 @@ onBeforeUnmount(() => {
   try { unlistenHangup?.() } catch {}
   try { unlistenPttDown?.() } catch {}
   try { unlistenPttUp?.() } catch {}
+  tones.dispose()
   stopElapsed()
   try { realtime.disconnect() } catch {}
 })
@@ -636,6 +654,19 @@ onBeforeUnmount(() => {
             Hold the button above. Set a hotkey in Settings &rsaquo; General to hold from any application.
           </template>
         </p>
+      </div>
+
+      <div class="field">
+        <label class="switch row">
+          <input type="checkbox" v-model="session.callTones" />
+          <span class="switch-text">
+            <span class="switch-label">Call tones</span>
+            <span class="switch-hint">
+              Rings while the call connects and beeps once when it is ready, so a call started
+              from the hotkey tells you where it is without the window being visible.
+            </span>
+          </span>
+        </label>
       </div>
 
       <div class="field">

--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -323,7 +323,10 @@ const realtime = useAssistantRealtime({
   onDisconnected: () => { ui.connected = false; ui.connecting = false; statusText.value = 'Idle'; stopElapsed(); syncPill('hidden') },
   onError: (err: string) => { ui.error = err; props.notify?.(err, 'error'); ui.connecting = false; ui.connected = false; statusText.value = 'Error'; try { debugLines.value.push(`[error] ${err}`) } catch {} },
   // Surfaced but does not change connection state: the call is still up.
-  onWarn: (msg: string) => { props.notify?.(msg, 'error'); try { debugLines.value.push(`[warn] ${msg}`) } catch {} },
+  // A rejected session.update leaves the audio call up but discards every
+  // setting in it, tools included. Surfacing that only as a transient toast
+  // made it look like nothing had happened, so it also stays on the panel.
+  onWarn: (msg: string) => { ui.error = msg; props.notify?.(msg, 'error'); try { debugLines.value.push(`[warn] ${msg}`) } catch {} },
   onLog: (msg: string) => {
     try {
       debugLines.value.push(msg)
@@ -401,6 +404,10 @@ onMounted(async () => {
       if (typeof ar.auto_close_minutes === 'number' && ar.auto_close_minutes >= 0) session.autoCloseMinutes = ar.auto_close_minutes
       if (ar.mic_mode === 'open' || ar.mic_mode === 'ptt') session.micMode = ar.mic_mode
       if (typeof ar.show_debug === 'boolean') ui.showDebug = ar.show_debug
+      // Without these the voice session came up with an empty tool list on every
+      // app start, and the only symptom was the model saying it had no tools.
+      if (typeof ar.enable_tools === 'boolean') ui.enableTools = ar.enable_tools
+      if (typeof ar.use_supervisor === 'boolean') ui.useSupervisor = ar.use_supervisor
     }
   } catch (e) {
     debugLines.value.push('[warn] failed to load assistant_realtime settings')
@@ -415,12 +422,20 @@ watch(() => debugLines.value.length, async () => {
   await scrollDebugToBottomIfEnabled()
 })
 
-watch(session, async () => {
+// `session` holds most controls, but the tools and supervisor switches live in
+// `ui` - and a `watch(session)` never fires for them. They were therefore never
+// written, and reset to false on every app start, which presented as the voice
+// model insisting it had no tools. `show_debug` was in the saved payload with
+// the same problem: it only reached disk when some unrelated `session` field
+// happened to change. Watch all three explicitly.
+watch([session, () => ui.enableTools, () => ui.useSupervisor, () => ui.showDebug], async () => {
   // Persist assistant_realtime settings immediately on change
   try {
     await invoke('save_settings', {
       map: {
         assistant_realtime: {
+          enable_tools: ui.enableTools,
+          use_supervisor: ui.useSupervisor,
           model: session.model,
           voice: session.voice,
           supervisor_mode: session.supervisorMode,

--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -150,6 +150,23 @@ async function copyTranscript() {
 }
 
 /**
+ * Copy the whole realtime event log.
+ *
+ * The log is where a rejected `session.update` shows up, and it is the only
+ * place the accepted tool list is visible - but it renders as a scrolling list
+ * of divs that is painful to select by hand, which made "paste me the log" a
+ * bigger ask than it should be.
+ */
+async function copyDebugLog() {
+  try {
+    await invoke('copy_text_to_clipboard', { text: debugLines.value.join('\n') })
+    props.notify?.(`Copied ${debugLines.value.length} log lines`, 'success')
+  } catch (e: any) {
+    props.notify?.(e?.message || 'Copy failed', 'error')
+  }
+}
+
+/**
  * Paste the transcript into whatever the user was last working in.
  *
  * The main window has focus while this button is being clicked, so the previous
@@ -740,6 +757,12 @@ onBeforeUnmount(() => {
     >
       <div v-for="(l, i) in debugLines" :key="i" class="log-line">{{ l }}</div>
       <div ref="debugLogBottomRef" style="height: 1px;"></div>
+    </div>
+
+    <div class="actions" v-if="ui.showDebug">
+      <button class="btn ghost" type="button" :disabled="!debugLines.length" @click="copyDebugLog">
+        Copy event log
+      </button>
     </div>
   </CollapsibleCard>
 </template>

--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -75,6 +75,7 @@ function syncPill(state: 'hidden' | 'armed' | 'live') {
     state,
     micOpen: state === 'live' ? micEnabled.value : false,
     hotkey: appSettings.push_to_talk_hotkey || '',
+    ptt: session.micMode === 'ptt',
   }).catch(() => {})
 }
 
@@ -320,6 +321,10 @@ async function syncSession() {
 
 watch(() => session.supervisorMode, syncSession)
 
+// The pill shows its hold-to-talk button only in push-to-talk, so a mode change
+// mid-call has to reach it or the button lingers or stays missing.
+watch(() => session.micMode, () => { if (ui.connected) syncPill('live') })
+
 // Load Prompt section settings (temperature, etc.) for supervisor alignment
 const { settings: appSettings, loadSettings } = useSettings()
 
@@ -478,6 +483,8 @@ watch(() => props.autostart, (n, old) => {
 })
 
 let unlistenHangup: UnlistenFn | null = null
+let unlistenPttDown: UnlistenFn | null = null
+let unlistenPttUp: UnlistenFn | null = null
 
 onMounted(async () => {
   window.addEventListener(HOTKEY_EVENT_PTT_DOWN, onPttDown)
@@ -487,6 +494,14 @@ onMounted(async () => {
   try {
     unlistenHangup = await listen('assistant:hangup', () => { void deactivate() })
   } catch {}
+  // Hold-to-talk from the pill's button. It runs in its own window and cannot
+  // reach the session, so it asks; these route to the same handlers the global
+  // hotkey uses, and the pill is non-activating so holding it never takes focus
+  // from whatever the user is working in.
+  try {
+    unlistenPttDown = await listen('assistant:ptt-down', () => onPttDown())
+    unlistenPttUp = await listen('assistant:ptt-up', () => onPttUp())
+  } catch {}
 })
 
 onBeforeUnmount(() => {
@@ -494,6 +509,8 @@ onBeforeUnmount(() => {
   window.removeEventListener(HOTKEY_EVENT_PTT_UP, onPttUp)
   if (armTimer) { clearTimeout(armTimer); armTimer = 0 }
   try { unlistenHangup?.() } catch {}
+  try { unlistenPttDown?.() } catch {}
+  try { unlistenPttUp?.() } catch {}
   stopElapsed()
   try { realtime.disconnect() } catch {}
 })

--- a/app/src/composables/useAssistantRealtime.ts
+++ b/app/src/composables/useAssistantRealtime.ts
@@ -343,6 +343,20 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
 
     if (type === 'session.updated') {
       try { log('[session.updated] ' + JSON.stringify(parsed?.session || {})) } catch {}
+      // The tools count was set optimistically before the payload was even
+      // sent, so it reported what this app built rather than what the session
+      // accepted - a rejected update left the badge reading 23 while the model
+      // had none. Correct it from the server's own echo when there is one.
+      try {
+        const accepted = parsed?.session?.tools
+        if (Array.isArray(accepted)) {
+          const sent = statusRef.value.toolsCount
+          if (accepted.length !== sent) {
+            log(`[warn] sent ${sent} tools but the session accepted ${accepted.length}`)
+          }
+          statusRef.value = { ...statusRef.value, toolsCount: accepted.length }
+        }
+      } catch {}
       return
     }
 

--- a/app/src/composables/useAssistantRealtime.ts
+++ b/app/src/composables/useAssistantRealtime.ts
@@ -163,6 +163,33 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     }, autoCloseMs)
   }
 
+  // The API allows exactly one response at a time. A tool call that takes tens
+  // of seconds leaves the microphone live with `create_response: true`, so the
+  // server can commit a turn and open its own response while we are still
+  // waiting on the tool - and the `response.create` we send with the result is
+  // then rejected with "Conversation already has an active response in
+  // progress". Losing that one event costs the user the answer entirely: the
+  // tool ran, the result is in the conversation, and nothing ever speaks it.
+  let responseActive = false
+  let pendingResponse: any | null = null
+
+  /**
+   * Ask for a spoken response, waiting for the current one if there is one.
+   *
+   * Only the most recent deferred request is kept. Two queued responses would
+   * be spoken back to back with the second answering a turn the user has
+   * already moved past.
+   */
+  function requestResponse(response?: any) {
+    const event = response ? { type: 'response.create', response } : { type: 'response.create' }
+    if (responseActive) {
+      pendingResponse = event
+      log('[response] one already in progress, deferred until it finishes')
+      return
+    }
+    send(event)
+  }
+
   function send(payload: any): boolean {
     if (!eventsDc || eventsDc.readyState !== 'open') {
       log('[warn] data channel not open, dropped: ' + (payload?.type || 'event'))
@@ -235,21 +262,15 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     try {
       const spoken = (await askSupervisor(userText)) || 'Sorry, I did not get a result for that.'
       history.value.push({ role: 'assistant', content: spoken })
-      const ok = send({
-        type: 'response.create',
-        response: {
-          instructions: `Say the following out loud, word for word, in the language it is written in. Do not summarise it, translate it, add to it, or comment on it:\n\n${spoken}`
-        }
+      requestResponse({
+        instructions: `Say the following out loud, word for word, in the language it is written in. Do not summarise it, translate it, add to it, or comment on it:\n\n${spoken}`
       })
-      if (ok) log('[supervisor] injected response (' + spoken.length + ' chars)')
+      log('[supervisor] injected response (' + spoken.length + ' chars)')
     } catch (e) {
       const msg = (e as any)?.message || String(e)
       log('[supervisor] failed: ' + msg)
       // Say something rather than leaving the user in silence.
-      send({
-        type: 'response.create',
-        response: { instructions: 'Tell the user briefly that the supervisor could not answer that, then stop.' }
-      })
+      requestResponse({ instructions: 'Tell the user briefly that the supervisor could not answer that, then stop.' })
     }
   }
 
@@ -275,7 +296,7 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
           }
         })
       }
-      send({ type: 'response.create' })
+      requestResponse()
       return
     }
     toolRounds += 1
@@ -312,7 +333,7 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       })
     }
     // One response for the whole batch: the model now has every result.
-    send({ type: 'response.create' })
+    requestResponse()
   }
 
   function handleServerEvent(raw: string) {
@@ -392,7 +413,22 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       return
     }
 
+    if (type === 'response.created') {
+      responseActive = true
+      return
+    }
+
     if (type === 'response.done') {
+      // Clear the flag before anything below can ask for a new response, and
+      // flush whatever was deferred while this one was speaking.
+      responseActive = false
+      if (pendingResponse) {
+        const queued = pendingResponse
+        pendingResponse = null
+        log('[response] sending the deferred response')
+        send(queued)
+      }
+
       const output = Array.isArray(parsed?.response?.output) ? parsed.response.output : []
       const calls = output.filter((o: any) => o?.type === 'function_call')
       if (calls.length) {
@@ -414,6 +450,8 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       handledUserItems.clear()
       history.value = []
       voiceSent = false
+      responseActive = false
+      pendingResponse = null
       toolRounds = 0
       connected = false
 
@@ -739,6 +777,8 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     if (talkTimeout) { clearTimeout(talkTimeout); talkTimeout = 0 }
     handledUserItems.clear()
     voiceSent = false
+    responseActive = false
+    pendingResponse = null
     toolRounds = 0
     connected = false
     try { opts.onDisconnected?.() } catch {}

--- a/app/src/composables/useAssistantRealtime.ts
+++ b/app/src/composables/useAssistantRealtime.ts
@@ -579,9 +579,21 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     let toolsToSend: any[] = includeTools ? tools : []
     if (supervisorNeeded) toolsToSend = [SUPERVISOR_TOOL]
 
-    const supervisorNote = supervisorNeeded
-      ? ` Call ${SUPERVISOR_TOOL_NAME} whenever a question needs current information, the user's files or applications, or careful reasoning, and read its answer back.`
-      : (params.useSupervisor ? ' A supervisor model answers on your behalf.' : '')
+    // Which of the three tool arrangements this session actually ended up in.
+    //
+    // This has to survive custom instructions. The two switches are per-session
+    // and are not visible to whoever wrote the prompt, so a hand-written prompt
+    // cannot describe the arrangement correctly - and previously it replaced
+    // this note wholesale, which meant a prompt mentioning "the supervisor"
+    // outlived the supervisor being switched off, and a supervisor session lost
+    // the one sentence that tells the model to escalate at all.
+    const arrangementNote = supervisorNeeded
+      ? `Call ${SUPERVISOR_TOOL_NAME} whenever a question needs current information, the user's files or applications, or careful reasoning, and read its answer back. It is the only tool you have; there are no others in this session.`
+      : params.useSupervisor
+        ? 'A supervisor model answers on your behalf. Do not describe that arrangement to the user.'
+        : includeTools
+          ? 'There is no supervisor in this session, so do not mention one or wait for one. You have tools of your own: call them yourself when a question needs them. Some take up to a minute, so say you are checking before you call one, then give the answer when it arrives.'
+          : 'There is no supervisor and no tools in this session. Answer from your own knowledge, and say plainly when something is beyond it.'
 
     const turnDetection: Record<string, any> = {
       type: 'server_vad',
@@ -628,9 +640,13 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       session: {
         type: 'realtime',
         output_modalities: ['audio'],
-        instructions: (params.instructions && params.instructions.trim().length > 0)
-          ? params.instructions
-          : `You are an assistant in Assistant Mode. Speak clearly and concisely.${supervisorNote} IMPORTANT: Always reply in the same language the user is speaking/writing. If you are unsure, reply in English. Do not switch languages mid-conversation unless the user clearly switches.`,
+        // The arrangement note goes last so it wins on recency, and it is
+        // appended to custom instructions rather than replaced by them.
+        instructions: `${
+          (params.instructions && params.instructions.trim().length > 0)
+            ? params.instructions.trim()
+            : 'You are an assistant in Assistant Mode. Speak clearly and concisely. IMPORTANT: Always reply in the same language the user is speaking/writing. If you are unsure, reply in English. Do not switch languages mid-conversation unless the user clearly switches.'
+        }\n\n${arrangementNote}`,
         tools: toolsToSend,
         tool_choice: 'auto',
         audio,
@@ -654,6 +670,9 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
         useSupervisor: params.useSupervisor === true,
         supervisorMode: currentSupervisorMode,
         enableTools: includeTools,
+        arrangement: supervisorNeeded
+          ? 'supervisor-needed'
+          : params.useSupervisor ? 'supervisor-always' : (includeTools ? 'tools-direct' : 'no-tools'),
         tool_count: toolsToSend.length,
         tool_names_sample: toolNames,
       }))

--- a/app/src/composables/useAssistantRealtime.ts
+++ b/app/src/composables/useAssistantRealtime.ts
@@ -29,6 +29,11 @@ const MAX_IDLE_TIMEOUT_MS = 30000
 // Longest a single push-to-talk hold may keep the microphone open.
 const MAX_TALK_MS = 60000
 
+// Shortest hold that is treated as speech. `input_audio_buffer.commit` is
+// rejected when the buffer holds less than 100ms of audio, so a stray tap of
+// the key would otherwise raise an API error instead of being ignored.
+const MIN_TALK_MS = 200
+
 // Escalation to the supervisor, expressed as something the model can choose to
 // do. This replaces a keyword list that only recognised English - the model
 // knows when a question is beyond it regardless of the language it is asked in.
@@ -119,6 +124,9 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
   // which is the exact thing push-to-talk exists to prevent. Global shortcuts
   // can miss a release when focus changes mid-press, so the hold is bounded.
   let talkTimeout: any = 0
+  // When the current push-to-talk hold began, or 0 when no turn is open. Both
+  // the length check and the idempotence of `commitPttTurn` hang off this.
+  let talkStartedAt = 0
   // Whether this session's push-to-talk paused the user's music.
   let mediaHeld = false
   // Whether the SDP exchange has completed. Server-side errors before that
@@ -654,7 +662,18 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     }
 
     const audioInput: Record<string, any> = {
-      turn_detection: turnDetection,
+      // Push-to-talk already knows where the turn ends: the key coming up is
+      // the end of it. Leaving server VAD switched on made every release wait
+      // out silence_duration_ms before the model would answer - a disabled
+      // WebRTC track keeps transmitting silence, so the server sat listening
+      // for an end of speech it had already been given. That was dead air on
+      // every single turn, and at the configured 4200ms it dominated the
+      // conversation. `stopTalking` commits the buffer explicitly instead.
+      //
+      // null rather than omitted: session.update merges, so leaving the field
+      // out would preserve the previous value and switching back to open mic
+      // would never restore VAD.
+      turn_detection: micMode === 'ptt' ? null : turnDetection,
       // Always on. The transcript is what the debug log, the conversation
       // history and the supervisor all read; without it the session is a black
       // box even when it is working.
@@ -700,8 +719,9 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       const toolNames = toolsToSend.map((t: any) => t?.name || t?.function?.name || '').filter(Boolean).slice(0, 8)
       log('[session.update] ' + JSON.stringify({
         voice: audio.output?.voice ?? '(unchanged)',
-        silence_ms: turnDetection.silence_duration_ms,
-        idle_timeout_ms: turnDetection.idle_timeout_ms ?? null,
+        turn_detection: micMode === 'ptt' ? 'manual (push-to-talk)' : 'server_vad',
+        silence_ms: micMode === 'ptt' ? null : turnDetection.silence_duration_ms,
+        idle_timeout_ms: micMode === 'ptt' ? null : (turnDetection.idle_timeout_ms ?? null),
         noise_reduction: audioInput.noise_reduction ?? null,
         transcription: audioInput.transcription.model,
         reasoning_effort: (params.reasoningEffort && modelSupportsReasoning(params.model)) ? params.reasoningEffort : null,
@@ -799,9 +819,47 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     log(enabled ? '[mic] unmuted' : '[mic] muted')
   }
 
+  /**
+   * End a push-to-talk turn: commit what was captured and ask for an answer.
+   *
+   * This is what replaces server VAD in push-to-talk. It is idempotent - the
+   * hold cap and the key release both route through here, and whichever runs
+   * first clears the marker.
+   */
+  function commitPttTurn() {
+    if (!talkStartedAt) return
+    const heldMs = Date.now() - talkStartedAt
+    talkStartedAt = 0
+
+    if (heldMs < MIN_TALK_MS) {
+      log(`[mic] hold of ${heldMs}ms is too short to be speech, discarded`)
+      send({ type: 'input_audio_buffer.clear' })
+      return
+    }
+
+    send({ type: 'input_audio_buffer.commit' })
+    // In supervisor "always" mode the realtime model is deliberately held
+    // silent and `supervisorRespond` injects the answer once the transcript
+    // arrives, so asking for a response here would talk over it.
+    if (currentUseSupervisor && currentSupervisorMode === 'always') {
+      log(`[mic] committed ${heldMs}ms; the supervisor answers this turn`)
+      return
+    }
+    log(`[mic] committed ${heldMs}ms and asked for a response`)
+    requestResponse()
+  }
+
   /** Open the microphone for as long as the key or button is held. */
   function startTalking() {
     if (!connected || micMode !== 'ptt') return
+    // Barge-in. With server VAD off, `interrupt_response` no longer applies, so
+    // reaching for the key while the assistant is talking has to cut it off
+    // here or push-to-talk would be the one mode you cannot interrupt.
+    if (responseActive) {
+      send({ type: 'response.cancel' })
+      log('[mic] cancelled the response in progress')
+    }
+    talkStartedAt = Date.now()
     // Pause the user's music for the length of the hold. Fire and forget: a
     // media session that will not answer must not delay the microphone.
     invoke<boolean>('media_hold', { reason: 'assistant' })
@@ -811,6 +869,9 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     talkTimeout = setTimeout(() => {
       log(`[mic] hold exceeded ${Math.round(MAX_TALK_MS / 1000)}s, closing the microphone`)
       setMicEnabled(false)
+      // Hitting the cap still ends a turn. Without this the speech captured up
+      // to the cap was left uncommitted and simply discarded.
+      commitPttTurn()
     }, MAX_TALK_MS)
     if (!micEnabled.value) setMicEnabled(true)
   }
@@ -824,6 +885,7 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
     }
     if (micMode !== 'ptt') return
     if (micEnabled.value) setMicEnabled(false)
+    commitPttTurn()
   }
 
   function attachAudioElement(el: HTMLAudioElement) {

--- a/app/src/composables/useCallTones.ts
+++ b/app/src/composables/useCallTones.ts
@@ -1,0 +1,152 @@
+/**
+ * Ringback and connect tones for Assistant Mode.
+ *
+ * Starting a call takes a second or two - an ephemeral token, an SDP exchange,
+ * ICE - and until the first audio arrives there is nothing to tell the user
+ * whether anything is happening. A phone solved this decades ago: you hear
+ * ringing while it connects, and it stops when the other end picks up.
+ *
+ * Synthesised rather than shipped as audio files: it is two oscillators, it
+ * keeps the bundle free of binary assets, and there is no decode latency on a
+ * path where latency is the whole complaint.
+ *
+ * German/CEPT ringback, since that is where this is used: a 425 Hz tone, one
+ * second on, four off.
+ */
+
+const RING_FREQ_HZ = 425
+const RING_ON_S = 1.0
+const RING_PERIOD_S = 5.0
+/** Deliberately quiet - this plays over whatever the user is working in. */
+const RING_PEAK = 0.05
+/** Bursts scheduled up front. Well past any connect that is going to succeed. */
+const RING_BURSTS = 24
+
+const BEEP_FREQ_HZ = 880
+const BEEP_LEN_S = 0.13
+const BEEP_PEAK = 0.07
+
+export function useCallTones() {
+  let ctx: AudioContext | null = null
+  let ringOsc: OscillatorNode | null = null
+  let ringGain: GainNode | null = null
+
+  /**
+   * The context is created on demand and kept.
+   *
+   * A call starts from a global hotkey, which is not a user gesture as far as
+   * the WebView is concerned, so the context can come up suspended. Resuming is
+   * best-effort: silent tones are a cosmetic loss, and must never take the call
+   * down with them.
+   */
+  function ensureCtx(): AudioContext | null {
+    try {
+      if (!ctx) {
+        const Ctor: typeof AudioContext | undefined =
+          (window as any).AudioContext || (window as any).webkitAudioContext
+        if (!Ctor) return null
+        ctx = new Ctor()
+      }
+      if (ctx.state === 'suspended') void ctx.resume().catch(() => {})
+      return ctx
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Start ringing, and keep ringing until `stopRingback`.
+   *
+   * The whole pattern is scheduled on the audio clock up front rather than
+   * driven by a timer, because the main window is usually hidden behind another
+   * application while a call connects and background timers get throttled - the
+   * ring would stutter exactly when it is the only feedback there is.
+   */
+  function startRingback() {
+    stopRingback()
+    const c = ensureCtx()
+    if (!c) return
+    try {
+      const osc = c.createOscillator()
+      osc.type = 'sine'
+      osc.frequency.value = RING_FREQ_HZ
+
+      const gain = c.createGain()
+      gain.gain.value = 0
+      osc.connect(gain)
+      gain.connect(c.destination)
+
+      const t0 = c.currentTime + 0.05
+      for (let i = 0; i < RING_BURSTS; i++) {
+        const on = t0 + i * RING_PERIOD_S
+        // Ramped rather than switched: a square edge on a sine is an audible
+        // click, and this is meant to be unobtrusive.
+        gain.gain.setValueAtTime(0, on)
+        gain.gain.linearRampToValueAtTime(RING_PEAK, on + 0.04)
+        gain.gain.setValueAtTime(RING_PEAK, on + RING_ON_S - 0.04)
+        gain.gain.linearRampToValueAtTime(0, on + RING_ON_S)
+      }
+
+      osc.start(t0)
+      osc.stop(t0 + RING_BURSTS * RING_PERIOD_S)
+      ringOsc = osc
+      ringGain = gain
+    } catch {
+      stopRingback()
+    }
+  }
+
+  /** Stop ringing immediately, with a short fade so it does not click. */
+  function stopRingback() {
+    const c = ctx
+    const osc = ringOsc
+    const gain = ringGain
+    ringOsc = null
+    ringGain = null
+    if (!c || !osc || !gain) return
+    try {
+      const now = c.currentTime
+      gain.gain.cancelScheduledValues(now)
+      gain.gain.setValueAtTime(gain.gain.value, now)
+      gain.gain.linearRampToValueAtTime(0, now + 0.05)
+      osc.stop(now + 0.06)
+    } catch {}
+    // Detaching on end keeps a long session from accumulating dead nodes.
+    try { osc.onended = () => { try { osc.disconnect(); gain.disconnect() } catch {} } } catch {}
+  }
+
+  /** One soft beep: the far end picked up. */
+  function readyBeep() {
+    const c = ensureCtx()
+    if (!c) return
+    try {
+      const osc = c.createOscillator()
+      osc.type = 'sine'
+      osc.frequency.value = BEEP_FREQ_HZ
+
+      const gain = c.createGain()
+      gain.gain.value = 0
+      osc.connect(gain)
+      gain.connect(c.destination)
+
+      const t0 = c.currentTime + 0.02
+      gain.gain.setValueAtTime(0, t0)
+      gain.gain.linearRampToValueAtTime(BEEP_PEAK, t0 + 0.02)
+      gain.gain.exponentialRampToValueAtTime(0.0001, t0 + BEEP_LEN_S)
+
+      osc.start(t0)
+      osc.stop(t0 + BEEP_LEN_S + 0.02)
+      osc.onended = () => { try { osc.disconnect(); gain.disconnect() } catch {} }
+    } catch {}
+  }
+
+  /** Release the audio device. Called when the panel goes away. */
+  function dispose() {
+    stopRingback()
+    const c = ctx
+    ctx = null
+    try { void c?.close() } catch {}
+  }
+
+  return { startRingback, stopRingback, readyBeep, dispose }
+}

--- a/specs/ClaudeCode_Integration_options.md
+++ b/specs/ClaudeCode_Integration_options.md
@@ -68,6 +68,53 @@ conversation history. Anything that can answer a string can be the brain of Alex
 call. That is the integration point, and everything below is really about the cheapest way
 to put Claude Code behind it.
 
+#### 1.2.1 Which tools the realtime model actually receives
+
+This gate is easy to get wrong and it decides whether an MCP server is visible to the voice
+at all. From `useAssistantRealtime.ts:563-566`:
+
+```js
+const supervisorNeeded = params.useSupervisor === true && currentSupervisorMode === 'needed'
+const includeTools     = params.enableTools === true && params.useSupervisor !== true
+let toolsToSend        = includeTools ? tools : []
+if (supervisorNeeded) toolsToSend = [SUPERVISOR_TOOL]
+```
+
+| "Enable MCP tools" | "Use supervisor agent" | `supervisor_mode` | Realtime model receives |
+|---|---|---|---|
+| off | off | - | **nothing** (this is the default state) |
+| **on** | **off** | - | **all MCP tools**, named `mcp__<server_id>__<tool>` |
+| any | on | `always` | nothing - it is only a voice; the supervisor answers every turn |
+| any | on | `needed` | **only** `consult_supervisor` |
+
+The consequence that matters: **MCP tools and the supervisor are mutually exclusive for the
+realtime model.** Turning the supervisor on does not give the voice model MCP tools plus an
+escalation path - it *replaces* the MCP tools with a single `consult_supervisor` tool. The
+MCP tools are still reachable, but one layer down, because the supervisor itself runs through
+`chat_complete_with_mcp`, which builds its tool list from every connected MCP client.
+
+So there are two distinct ways to reach a Claude Code shim, and they are not the same thing:
+
+- **Direct:** "Enable MCP tools" on, supervisor off. The realtime model calls
+  `mcp__Rob__ask_claude` itself. Fewer hops, lower latency, but the realtime model is the one
+  deciding when and with what arguments - and it is the weakest model in the chain.
+- **Via the supervisor:** supervisor on, mode `needed`. The realtime model can only call
+  `consult_supervisor`; GPT then decides whether to call `mcp__Rob__ask_claude`. One extra
+  hop and one extra model's latency, but a much better tool-caller, and it sees the last 20
+  turns of transcript.
+
+Two further gotchas, both of which will present as "the assistant says it has no such tool":
+
+- **Neither toggle is persisted.** `AssistantMode.vue:22-23` default both to `false`, and the
+  `assistant_realtime` save block writes 11 fields but not these two. They reset on every app
+  start. (Worth fixing; see §7.14.)
+- **Tools are fixed at `session.update` time.** Only `enableTools`, `useSupervisor` and
+  `supervisorMode` have watchers that call `syncSession`. Connecting an MCP server *during* a
+  live call does not re-push the tool list; the call has to be restarted, or a toggle flipped.
+
+The header badge **"Tools N"** in the Assistant Mode panel renders `statusRef.toolsCount` and
+is the correct diagnostic for all of the above.
+
 ### 1.3 What was missed: an in-process loopback HTTP server already exists
 
 `app/src-tauri/src/tts_streaming_server.rs` runs a **hyper 1.x HTTP/1 server bound to
@@ -197,8 +244,11 @@ Servers -> stdio, `command: node`, `args: [C:\Rob\...\claude-bridge.mjs]`. Nothi
 repository changes.
 
 And because `realtime_build_tools` flattens every connected MCP server's tools into the
-realtime session, **the tool immediately appears to the live voice call as well as to the
-Prompt panel.** One shim lights up both surfaces.
+realtime session, **the tool appears to the live voice call as well as to the Prompt panel**
+- one shim lights up both surfaces. But only under the conditions in §1.2.1: "Enable MCP
+tools" on, "Use supervisor agent" off, the server showing `connected`, and the call started
+after the server connected. With the default toggles the realtime model receives an empty
+tool list and will simply say it has no such tool.
 
 - **Effort here: zero.** All of it lands on the Rob side, roughly half a day.
 - **Risk: latency inside a synchronous tool call.** A `claude -p` that takes 40 s blocks the
@@ -210,11 +260,20 @@ Prompt panel.** One shim lights up both surfaces.
 - **Risk: transcription quality.** `DEFAULT_TRANSCRIPTION_MODEL = 'gpt-4o-transcribe'` feeds
   the tool arguments. Project names and file paths spoken aloud will arrive mangled.
 
-**A2 - same shim, used as the escalation path.** Set `supervisor_mode: 'needed'`, drop the
-built-in `consult_supervisor` in favour of `ask_claude` (or keep both), and write Assistant
-Mode `instructions` telling the model to route anything about Alex's files, mail, tasks or
-projects to Claude Code. The realtime model then handles only turn-taking and chit-chat.
-This *is* the "ongoing call with Claude Code", assembled from parts that already exist.
+**A2 - same shim, reached through the supervisor instead.** Note that `consult_supervisor`
+cannot be swapped for `ask_claude`: in `needed` mode `toolsToSend` is hardcoded to
+`[SUPERVISOR_TOOL]` (§1.2.1). The escalation path is therefore two hops, not one - the
+realtime model calls `consult_supervisor`, and GPT (running `chat_complete_with_mcp`, which
+sees every connected MCP server) decides whether to call `mcp__Rob__ask_claude`. Steer that
+decision from the **Prompt-section system prompt**, not from the Assistant Mode instructions,
+since it is GPT making the call.
+
+Both A1-direct and A2-via-supervisor produce "an ongoing call with Claude Code" out of parts
+that already exist. A2 costs one extra model round-trip but gets a far better tool-caller,
+and the supervisor already receives the last 20 turns of transcript. Try A1-direct first
+because it is one less moving part, and fall back to A2 if the realtime model calls the tool
+badly - which, given it is the weakest model in the chain and its arguments come from
+speech-to-text, is likely.
 
 ### B. Companion exposes an MCP server that Claude Code connects to
 
@@ -336,11 +395,11 @@ Notes that matter:
 
 Given §1.2, this is the shortest line between here and what Alex asked for.
 
-**F1 - configuration only, zero code.** Register the A1 shim as an MCP server, set
-`supervisor_mode: 'needed'`, and write Assistant Mode instructions that route anything real
-to `ask_claude`. The realtime model keeps the call alive and handles turn-taking; Claude Code
-answers; the realtime voice reads the answer back. **This is A1+A2 and it is the
-recommendation.**
+**F1 - configuration only, zero code.** Register the A1 shim as an MCP server and pick one of
+the two routings in §1.2.1: either "Enable MCP tools" on with the supervisor off, so the
+realtime model calls `mcp__Rob__ask_claude` directly, or the supervisor on in `needed` mode,
+so GPT calls it on the realtime model's behalf. Either way the realtime voice reads the
+answer back and the call keeps running. **This is A1+A2 and it is the recommendation.**
 
 **F2 - a settings-driven supervisor base URL.** Add `prompt_base_url` to settings, following
 the `*_from_settings_or_env` pattern that STT and TTS already use, and let
@@ -406,11 +465,16 @@ like inside a live voice call?* - in front of Alex before anyone writes Rust.
 
 1. Rob side: a stdio MCP server exposing exactly two tools - `ask_claude(question)`
    (routed to a named `claude --bg` session, returns text) and `claude_status()`.
-2. Companion: Settings -> MCP Servers -> add it as a stdio server. No code change.
-3. Assistant Mode: `supervisor_mode: 'needed'`; instructions telling the model to call
-   `ask_claude` for anything about Alex's files, mail, tasks or projects.
-4. Hold the push-to-talk key, say *"ask Claude what is on my calendar tomorrow"*, and hear
-   the answer in the realtime voice.
+2. Companion: Settings -> MCP Servers -> add it as a stdio server, and **connect it** (the
+   chip must read `connected`; the tool list is built from live clients only).
+3. Assistant Mode: tick **"Enable MCP tools"** and leave **"Use supervisor agent"** off.
+   Confirm the header badge reads **"Tools N"** with N greater than zero *before* testing -
+   both toggles default off and are not persisted, so this is step zero on every app start
+   (§1.2.1).
+4. Hold the push-to-talk key, say *"use ask_claude to tell me what is on my calendar
+   tomorrow"*, and hear the answer in the realtime voice. Refer to the tool by its function,
+   not by the server name: it is registered as `mcp__Rob__ask_claude`, and there is no tool
+   called "Rob".
 
 **Effort: about half a day, all of it on the Rob side.**
 
@@ -492,3 +556,10 @@ Flagged bluntly, because they will each cost an afternoon if discovered late.
 13. **Transcription quality feeds tool arguments.** Spoken project names, file paths and
     ticket ids will arrive mangled from `gpt-4o-transcribe`. Any tool taking an identifier
     needs fuzzy resolution on the Claude Code side.
+14. **"Enable MCP tools" and "Use supervisor agent" are not persisted.** Every other Assistant
+    Mode control is written to `assistant_realtime` on change; these two are not, so they
+    reset to `false` on every app start and the voice session silently comes up with no tools.
+    This is a small, self-contained fix (two fields in the save block at
+    `AssistantMode.vue:421-437` and two in the load block above it) and it should be done
+    before any of this is used in anger - otherwise the first symptom of every session is
+    "the assistant says it has no such tool".

--- a/specs/ClaudeCode_Integration_options.md
+++ b/specs/ClaudeCode_Integration_options.md
@@ -1,0 +1,494 @@
+# Claude Code integration - options and recommendation
+
+Status: **design note, nothing implemented.** Written in response to a request from the
+Claude Code session running in `C:\Rob`, which asked for a read-only assessment of how
+AiDesktopCompanion could become the voice front-end for a live Claude Code session.
+
+Goal, in Alex's words: *"a real assistant call ongoing, so to speak, and I can communicate
+with it"* - a persistent, voice-first channel where the companion is the microphone,
+speaker and desktop UI, and Claude Code is the brain holding the real tools (Outlook/Graph,
+ClickUp, Teams, the work-brain knowledge base, file index, browser automation, the M3 MCP
+servers). Push in both directions: Alex talks to it, and it can speak up on its own when a
+background job finishes.
+
+---
+
+## 1. Correcting the picture of this app
+
+The externally-supplied summary was accurate as far as it went, but it missed the single
+most important thing in the codebase for this purpose, and got two details wrong.
+
+### 1.1 What was missed: Assistant Mode is already a full-duplex realtime voice call
+
+`app/src/composables/useAssistantRealtime.ts` (773 lines) plus
+`app/src/components/assistant/AssistantMode.vue` (793 lines) implement a **WebRTC session
+against the OpenAI Realtime API**. This is not "the assistant chat panel". It is a live
+phone call with the model. Concretely, all of the following already work:
+
+| Capability | Where |
+|---|---|
+| WebRTC peer connection, bidirectional audio, ephemeral-token auth | `useAssistantRealtime.ts` `connect()`; token minted in Rust by `realtime_create_ephemeral_token` so the real API key never enters the WebView |
+| Server-side VAD / endpointing, configurable `silence_duration_ms`, `idle_timeout_ms` (API cap 30 s), optional input noise reduction | `sendSessionUpdate()` |
+| Barge-in | native to Realtime over WebRTC; nothing in this app suppresses it |
+| Open-mic **and** push-to-talk, with a dedicated global hotkey slot (`push_to_talk_hotkey`, down/up events, 60 s max hold as a dropped-key-up guard) | `app/src/hotkeys.ts`, `startTalking()` / `stopTalking()` |
+| Music pause while the mic is open, via WinRT media transport controls | `app/src-tauri/src/media.rs`, `media_hold` / `media_release` |
+| Always-on-top, non-focus-stealing "call pill" with armed/live states, elapsed timer and a hang-up button, stacking above the busy pill | `app/src-tauri/src/assistant_pill.rs`, `AssistantPill.vue`, window `assistant-pill` declared statically in `tauri.conf.json` |
+| Auto-close after N minutes of inactivity (realtime bills by the minute) | `resetAutoClose()` |
+| Live rolling transcript of both sides, rendered in the panel | `history` ref |
+| MCP tools exposed **to the realtime model itself** | `realtime_build_tools` flattens `build_openai_tools_from_mcp` output into realtime function-tool shape; `realtime_call_tool` executes them |
+| Insert the assistant's answer into the previously focused app | `AssistantMode.vue` -> `refocus_previous_app` + `insert_text_into_focused_app` |
+
+### 1.2 What was missed: there is already a "supervisor" escalation seam
+
+This is the finding that should drive the whole design.
+
+The realtime model is fast and cheap but weak. So the code gives it a tool called
+`consult_supervisor`, described as *"Ask the supervisor model, which is slower but far more
+capable and has access to tools, files and the internet."* When the realtime model calls it:
+
+```
+realtime model calls consult_supervisor(question)
+  -> askSupervisor()  (useAssistantRealtime.ts:201)
+     -> invoke('chat_complete', { messages })          // last 20 turns + the question
+        -> chat::chat_complete_with_mcp()              // OpenAI chat completions + MCP tool loop
+  -> answer text comes back
+  -> response.create with "Say the following out loud, word for word"
+  -> the realtime voice reads the supervisor's answer verbatim
+```
+
+Two modes, persisted as `assistant_realtime.supervisor_mode`:
+
+- **`always`** - the realtime model is held silent (`create_response: false`) and the
+  supervisor answers *every* user turn.
+- **`needed`** - the realtime model handles what it can and escalates on its own.
+
+**This is a text-in / text-out hole in the middle of a live, working voice call.** It is
+already wired to the microphone, the speaker, the transcript, the turn-taking and the
+conversation history. Anything that can answer a string can be the brain of Alex's ongoing
+call. That is the integration point, and everything below is really about the cheapest way
+to put Claude Code behind it.
+
+### 1.3 What was missed: an in-process loopback HTTP server already exists
+
+`app/src-tauri/src/tts_streaming_server.rs` runs a **hyper 1.x HTTP/1 server bound to
+`127.0.0.1`** inside the Tauri process, with its own accept loop, a session map and an idle
+reaper. It exists to stream OpenAI TTS audio to the WebView (which is why `media-src` in the
+CSP allows `http://127.0.0.1`).
+
+So "run a loopback HTTP bridge in the Tauri process" is not new ground here - the
+dependencies (`hyper`, `hyper-util`, `http-body-util`, `bytes`) are already in `Cargo.toml`
+and there is a working, tested pattern to copy. Two caveats: it binds `127.0.0.1:0`
+(**ephemeral port**, so a bridge needs a discovery file or a fixed port), and it is started
+lazily by the OpenAI TTS path rather than at app startup.
+
+### 1.4 What was missed: Alex already has a working "Rob, ..." pipeline, and it is bad
+
+`%APPDATA%\AiDesktopCompanion\hooks\command.ps1` exists on this machine (5.6 KB, last
+modified 2026-05-26). It:
+
+1. matches `^Rob\b...` on the transcript,
+2. finds a Windows Terminal tab whose title contains `ROB` via UI Automation, launching
+   `wt -d C:\rob --title ROB claude` and sleeping 3 s if there is none,
+3. selects the tab, `SetForegroundWindow`s it, walks the UIA tree to focus the `TermControl`
+   pane,
+4. `Set-Clipboard` + `SendKeys ^v` + `SendKeys {ENTER}`.
+
+It works, and it is exactly the thing to replace. Its problems are the requirements list for
+this project: it **steals focus** mid-sentence, it **clobbers the clipboard**, it depends on
+UI Automation against Windows Terminal's control tree, there is **no answer channel at all**
+(Alex has to look at the terminal), and nothing is ever spoken back.
+
+### 1.5 Two details to correct
+
+- **MCP transport is stdio or *streamable HTTP*, not SSE.** `rmcp` was moved to 3.1 and the
+  standalone SSE client transport was dropped; the frontend normalises a server marked `sse`
+  to `http` before it reaches Rust. See the comment in `Cargo.toml` above the `rmcp` line.
+- **`rmcp` is compiled with the `client` feature only.** There is no MCP *server* capability
+  in the binary today. Adding one is a real change, not a flag flip - see option B.
+
+### 1.6 Everything else in the summary was right
+
+Single `index.html` with `?window=` dispatch (now five windows: `main`, `quick-actions`,
+`capture-overlay`, `busy-indicator`, `assistant-pill`); Quick Actions popup with aggressive
+clipboard copy/restore; local Whisper/Parakeet plus cloud STT; Windows-native and OpenAI TTS;
+`chat.rs` MCP tool loop; `mcp.rs` rmcp client with a global `MCP_CLIENTS` map; Command Mode
+hook; locked-down CSP.
+
+---
+
+## 2. Facts that constrain every option below
+
+These are the load-bearing details. Read this section before judging the options.
+
+**Command Mode is fire-and-forget. There is no return channel.**
+`command_hook.rs:436-438` sets `stdout` and `stderr` to the *log file*, not a pipe. The exit
+code is logged and thrown away. The app never reads a byte back from the script. Contract:
+
+- **In:** transcript on stdin, plus env `AIDC_TRANSCRIPT`, `AIDC_ACTIVE_APP` (foreground
+  process name at trigger time), `AIDC_CLIPBOARD`, `AIDC_SELECTED_TEXT`. Empty values are
+  passed as empty strings, never absent.
+- **Out:** nothing. Whatever the hook wants to happen, the hook must make happen itself.
+- **Concurrency:** `COMMAND_RUNNING: AtomicBool` single-flight. A second `C` while one runs
+  is a silent no-op.
+- **Timeout:** `command_hook_timeout_secs`, default **120 s** (settable, clamped to 5-3600 s
+  in `config.rs`), then `child.kill()`. Children
+  the script itself spawned are *not* reaped - detaching long work with `Start-Process` is
+  explicitly the script author's job.
+- **Events:** `command:state` (`running` / `idle`) and `command:error` are emitted to the
+  frontend.
+
+**`chat_complete` hardcodes `https://api.openai.com/v1/chat/completions`.**
+Both `chat::chat_complete_with_mcp` (line 115) and `chat::chat_complete` (line 316) have the
+URL inline. Unlike STT and TTS, the Prompt/supervisor path has **no configurable base URL**.
+Pointing the supervisor at a local endpoint therefore needs a Rust change - small, but not
+zero.
+
+**CSP allows loopback HTTP but not loopback WebSocket.**
+`connect-src` includes `http://127.0.0.1` with no port restriction, so `fetch` and
+`EventSource` against any loopback port work from the WebView today. `ws://127.0.0.1` is
+**not** listed, and CSP does not infer it from the `http://` entry. A WebSocket push channel
+requires editing both `csp` and `devCsp` in `tauri.conf.json`. **Prefer SSE + POST.**
+
+**The realtime call lives in the main window's WebView.**
+Hiding the main window to tray keeps it alive. Killing the WebView2 process does not.
+`webview_health.rs` exists precisely because WebView2 process failures are a live issue
+(#14). An always-on call turns a rare annoyance into a visible one.
+
+**Assistant Mode conversation state is in-memory and wiped on connect.**
+`history.value = []` at the top of `connect()`. Only the last 20 turns go to the supervisor,
+tool turns filtered out. Assistant Mode does **not** use `conversation_persist`. Hang up and
+the conversation is gone.
+
+**No single-instance guard.** `tauri-plugin-single-instance` is not a dependency. Two copies
+of the app would both try to bind a fixed bridge port.
+
+**Every new frontend capability needs a line in `generate_handler!`** in `lib.rs:91-172`.
+That list is the entire Rust/JS contract.
+
+**The Quick Actions popup must never be created or destroyed at runtime** - `popup.ts` only
+toggles visibility on the statically declared window. Any new agent-facing UI must follow the
+same rule.
+
+---
+
+## 3. The options
+
+### A. Companion as MCP client of Claude Code
+
+**Can it work?** Not directly. Claude Code is an MCP *client*; it exposes no MCP server
+endpoint to connect to. But the question is the wrong shape, because Claude Code does not
+need to *be* an MCP server - something on the Rob side can be one on its behalf.
+
+**A1 - a Rob-side stdio MCP shim.** A small server (Node, ~150 lines) that Claude Code's
+ecosystem owns, exposing tools like:
+
+```
+ask_claude(question, session?) -> string
+claude_sessions()              -> [{name, cwd, status}]
+send_to_session(name, text)    -> ack
+job_status(job_id)             -> {state, result?}
+```
+
+Internally it does whatever is most reliable on that side - `claude -p` for one-shots, or a
+directed message to a named `claude --bg` session for stateful work.
+
+The companion connects to it with the **MCP wiring that already exists**: Settings -> MCP
+Servers -> stdio, `command: node`, `args: [C:\Rob\...\claude-bridge.mjs]`. Nothing in this
+repository changes.
+
+And because `realtime_build_tools` flattens every connected MCP server's tools into the
+realtime session, **the tool immediately appears to the live voice call as well as to the
+Prompt panel.** One shim lights up both surfaces.
+
+- **Effort here: zero.** All of it lands on the Rob side, roughly half a day.
+- **Risk: latency inside a synchronous tool call.** A `claude -p` that takes 40 s blocks the
+  realtime turn with no audio at all. Two mitigations, ideally both: (a) make the blocking
+  tool fast-path only and add an async `claude_start` / `claude_poll` pair for real work;
+  (b) have the realtime model say a filler line before calling. Also unverified: rmcp 3.1's
+  default client request timeout, which may cut off a long tool call before Claude Code
+  finishes. Test a deliberately slow tool early.
+- **Risk: transcription quality.** `DEFAULT_TRANSCRIPTION_MODEL = 'gpt-4o-transcribe'` feeds
+  the tool arguments. Project names and file paths spoken aloud will arrive mangled.
+
+**A2 - same shim, used as the escalation path.** Set `supervisor_mode: 'needed'`, drop the
+built-in `consult_supervisor` in favour of `ask_claude` (or keep both), and write Assistant
+Mode `instructions` telling the model to route anything about Alex's files, mail, tasks or
+projects to Claude Code. The realtime model then handles only turn-taking and chit-chat.
+This *is* the "ongoing call with Claude Code", assembled from parts that already exist.
+
+### B. Companion exposes an MCP server that Claude Code connects to
+
+This is the push direction, and the peer session is right that it is the compelling one:
+`speak(text)`, `notify(text)`, `ask_user(question)`, `insert_into_focused_app(text)`,
+`capture_selection()`, `capture_screen()`, `say_in_call(text)`. It turns this app into Claude
+Code's eyes, ears and mouth.
+
+**B1 - in-process rmcp server over streamable HTTP.** Real work:
+
+- add `rmcp` server features and implement a `ServerHandler`;
+- rmcp's streamable-HTTP server transport is **axum-based**, so axum joins hyper in the
+  binary (or the MCP HTTP framing gets hand-rolled on the existing hyper server, which is
+  worse);
+- a **fixed, discoverable port** is required, because Claude Code's `.mcp.json` needs a
+  stable URL - which means port-conflict handling and a single-instance guard;
+- authentication is **not optional**: any local process could otherwise type into Alex's
+  desktop and read his screen.
+
+Estimate: 1-2 days for a first cut, plus hardening. Stdio is not an option - this is a GUI
+process, its stdin/stdout are not a pipe to Claude Code.
+
+**B2 - loopback REST + a thin external MCP shim. Recommended over B1.**
+
+The companion exposes a small plain-JSON surface on its own hyper server; a tiny stdio MCP
+server on the Rob side translates MCP calls into HTTP calls against it. Claude Code spawns
+the shim.
+
+Why this is better:
+
+- no `rmcp` server feature, no axum, no MCP protocol code in Rust;
+- the tool list can be iterated on the Rob side without touching or releasing this app;
+- the same REST surface serves option D unchanged;
+- the code to copy already exists in `tts_streaming_server.rs`.
+
+Sketch:
+
+```
+POST /speak            {text, voice?}       -> tts_start / tts_openai_stream_start
+POST /notify           {text, kind}         -> busy pill, or a toast
+POST /say-in-call      {text}               -> emits a Tauri event; AssistantMode injects it
+                                              into the live realtime session
+POST /ask              {question, timeout}  -> blocks, returns Alex's spoken/typed answer
+POST /insert           {text}               -> insert_text_into_focused_app  (gated, see §5)
+GET  /selection                             -> last_selected_text
+POST /capture                               -> region capture, returns a path
+GET  /state                                 -> {call: idle|live, busy: n, focused_app}
+GET  /events           (SSE)                -> user speech, hang-up, answers to /ask
+```
+
+Discovery and auth: write `%APPDATA%\AiDesktopCompanion\bridge.json` with `{port, token}` at
+startup, `0600`-equivalent ACL; bind `127.0.0.1` only; require the bearer token on every
+call; send **no** CORS headers and reject requests carrying an `Origin` header, so a web page
+cannot reach it. Off by default behind a settings toggle.
+
+Estimate: **0.5-1 day** for the endpoint set and the settings toggle, on top of an existing,
+tested server pattern.
+
+### C. Companion drives the `claude` CLI as a subprocess
+
+The companion owns a long-lived `claude` session directly, the way `rob-app` does.
+
+**Verdict: wrong layer.** It duplicates something Rob already does well, and it drags CLI
+concerns into a Tauri GUI: session resume, permission prompts, per-project working
+directories, and the CLI's known traps (a newline in a positional prompt is silently
+swallowed; `--allowedTools` eats the positional argument). The interesting sessions are
+per-project and belong to whatever manages projects - that is Rob, not this app.
+
+The only defensible narrow version is a stateless `claude -p` one-shot for "ask a question",
+and that is just option A1's shim living in the wrong repository.
+
+### D. Loopback HTTP bridge with SSE push
+
+Not really a separate option - it is the transport underneath B2, and the answer to the push
+direction. Worth stating explicitly:
+
+- **Companion -> Claude Code:** `GET /events` as SSE. The Rob side holds it open and receives
+  user speech, call state changes, and answers to pending `ask_user` calls.
+- **Claude Code -> Companion:** plain `POST`s as above.
+- Use **SSE, not WebSocket**, unless someone edits the CSP (§2). SSE also survives the
+  Tauri/WebView boundary without ceremony, and the companion is not the client here anyway -
+  the Rob-side shim is.
+
+### E. Command Mode hook as the cheap first step
+
+Real, and cheaper than anything else, but bounded by §2: **the hook has no return channel.**
+Anything the user is meant to hear, the hook must speak itself.
+
+Smallest useful version, replacing the current `command.ps1`:
+
+```powershell
+if ($transcript -notmatch '^(?i)Rob\b[\s,\.;:!?-]*(.+)$') { exit 0 }
+$text = $Matches[1].Trim()
+
+# Detach: the app kills this process after command_hook_timeout_secs (120 s default).
+Start-Process -WindowStyle Hidden powershell -ArgumentList @('-NoProfile','-Command', @"
+  `$answer = & claude -p '$($text -replace "'","''")' 2>&1 | Out-String
+  Add-Type -AssemblyName System.Speech
+  (New-Object System.Speech.Synthesis.SpeechSynthesizer).Speak(`$answer.Trim())
+"@)
+exit 0
+```
+
+Notes that matter:
+
+- **`Start-Process` to detach is mandatory**, not stylistic. A synchronous `claude -p` that
+  takes longer than 120 s gets killed mid-answer, and the single-flight `AtomicBool` blocks
+  `C` until it finishes. Raising `command_hook_timeout_secs` (clamped to 3600 s) helps, but
+  it also means `C` stays blocked for that whole time, so detaching is still the right shape.
+- Speaking is done in the hook via `System.Speech`, or by calling Rob's existing local TTS
+  MCP server (`mcp__tts__sapi_tts`). The companion's own TTS is *not* reachable from a script
+  today - that is exactly what option B2's `POST /speak` would fix.
+- No focus stealing, no clipboard clobber, no UI Automation. Strictly better than the current
+  hook on all three counts.
+- Ceiling: one-shot, no conversation, no interruption, no follow-up. It proves the wiring; it
+  is not the "ongoing call".
+
+### F. The option not on the list: make Claude Code the supervisor
+
+Given §1.2, this is the shortest line between here and what Alex asked for.
+
+**F1 - configuration only, zero code.** Register the A1 shim as an MCP server, set
+`supervisor_mode: 'needed'`, and write Assistant Mode instructions that route anything real
+to `ask_claude`. The realtime model keeps the call alive and handles turn-taking; Claude Code
+answers; the realtime voice reads the answer back. **This is A1+A2 and it is the
+recommendation.**
+
+**F2 - a settings-driven supervisor base URL.** Add `prompt_base_url` to settings, following
+the `*_from_settings_or_env` pattern that STT and TTS already use, and let
+`chat_complete_with_mcp` POST there instead of `api.openai.com`. Rob then serves an
+OpenAI-compatible `POST /v1/chat/completions` backed by a resident Claude Code session, and
+**every** supervisor turn is Claude Code, with the full conversation history the composable
+already assembles.
+
+- Cost here: **2-4 hours** (one setting, one URL, one settings-UI field). Genuinely small.
+- Cost on the Rob side: a non-streaming, no-tool-calls completions shim is maybe 100 lines;
+  supporting streaming and `tool_calls` properly is considerably more.
+- Caveat: in `always` mode this puts Claude Code in the path of *every* utterance including
+  "hello", which will feel terrible. Use `needed`, or the hybrid where GPT stays the
+  supervisor and simply holds `ask_claude` as one more tool.
+
+---
+
+## 4. The "ongoing call" question, honestly assessed
+
+| Requirement | State today | Work to close |
+|---|---|---|
+| Continuous open microphone | **Works.** `mic_mode: 'open'` | none |
+| Push-to-talk and hold | **Works.** Global hotkey slot, down/up events, 60 s hold guard, media pause | none |
+| VAD / endpointing | **Works.** Server-side turn detection, configurable silence, idle timeout to 30 s, optional noise reduction | none |
+| Barge-in | **Works.** Native to Realtime/WebRTC | none |
+| Streaming partial output to TTS | **Works for the realtime voice** (it is the audio stream). **Absent for supervisor answers** - `askSupervisor` awaits a complete string, then the model reads it back | **Moderate.** Chunk the supervisor answer and inject incremental `response.create` calls |
+| Turn-taking while the brain is slow | **Missing.** A 40 s Claude Code answer is 40 s of dead air with no indication anything is happening | **Small for a filler line** ("say you are looking into it" before awaiting). **Moderate** for real progress interjections, which need the push channel |
+| Conversation state across turns | **Partial.** In-memory, last 20 turns to the supervisor, wiped on every connect, never persisted | **Small** if Claude Code holds the state instead (a named `--bg` session) - which is an argument for F1. **Moderate** to persist Assistant Mode conversations locally |
+| Wake word | **Does not exist.** No always-listening keyword spotter anywhere in the codebase | **New subsystem** (openWakeWord / Porcupine + a resident capture loop + a settings surface). Not a rewrite of the app, but genuinely new. PTT plus open-mic-with-idle-timeout is the pragmatic substitute and it is already built |
+| Survives the window being hidden | **Works** hidden to tray. **Dies** if WebView2 dies (#14) | Watch `webview_health.rs`; an always-on call makes this failure mode routine |
+| Cost | Realtime bills by the minute. `auto_close_minutes` exists for a reason | A literally always-on call is expensive; expect to keep auto-close |
+
+**Nothing in this list is a rewrite.** The hard parts of a voice loop - WebRTC, VAD,
+barge-in, PTT, the call pill, media ducking - are done. The two real gaps are **filling the
+silence while a slow brain thinks** and **streaming a long answer instead of waiting for
+it**, and both are contained inside `useAssistantRealtime.ts`.
+
+---
+
+## 5. The push direction: which surfaces are reusable
+
+| Surface | Reusable? | Notes |
+|---|---|---|
+| **Spoken TTS, headless** | **As-is.** | `tts_start` -> `tts_win_native::local_tts_start` needs no window and steals no focus. `tts_openai_stream_start` gives the better cloud voice. Both only need an entry point Claude Code can reach - that is the whole of `POST /speak`. |
+| **Busy-indicator pill** | **As-is.** | `busy::start` / `finish` / `with_indicator`. Always-on-top, `WS_EX_NOACTIVATE`, bottom-right of the monitor under the cursor, elapsed counter, error state that persists until clicked. Exactly right for "Claude Code is working on X". One deliberate behaviour to know: it stays hidden when the main window is already in front. |
+| **Assistant call pill** | **Pattern reusable**, code is call-specific. | Separate always-on-top window, stacks above the busy pill, `armed`/`live` states with a hang-up button. A "Claude wants you" pill would clone this rather than extend it. |
+| **Tray** | Exists, minimal. | `TrayIconBuilder` with Show/Exit and click-to-toggle. No balloon/notification API is used. |
+| **Real Windows toast** | **Not available.** | `tauri-plugin-notification` is not a dependency. Adding it is easy but it is an addition, not a reuse. |
+| **Interruptible prompt / `ask_user`** | **Does not exist.** | The Quick Actions window is the natural home - already static, always-on-top, non-focus-stealing, never destroyed - but it has no "question from an agent" mode. New UI plus a pending-question state machine. Moderate. |
+| **Speaking into a live call** | **Cheap and the best of the lot.** | If a call is up, `conversation.item.create` + `response.create` on the existing data channel makes Claude Code's message something the assistant *says*, mid-conversation, in the same voice. A Tauri event listener in `AssistantMode.vue` plus a `POST /say-in-call` endpoint. Roughly 20 lines of frontend and one endpoint. |
+
+---
+
+## 6. Recommendation
+
+### First path: A1 + F1 (the Rob-side MCP shim, consumed by the existing supervisor seam)
+
+Because it costs **nothing in this repository**, it uses wiring that is already built and
+tested, and it puts the real question - *what does the latency of a Claude Code answer feel
+like inside a live voice call?* - in front of Alex before anyone writes Rust.
+
+**Smallest end-to-end slice that proves it:**
+
+1. Rob side: a stdio MCP server exposing exactly two tools - `ask_claude(question)`
+   (routed to a named `claude --bg` session, returns text) and `claude_status()`.
+2. Companion: Settings -> MCP Servers -> add it as a stdio server. No code change.
+3. Assistant Mode: `supervisor_mode: 'needed'`; instructions telling the model to call
+   `ask_claude` for anything about Alex's files, mail, tasks or projects.
+4. Hold the push-to-talk key, say *"ask Claude what is on my calendar tomorrow"*, and hear
+   the answer in the realtime voice.
+
+**Effort: about half a day, all of it on the Rob side.**
+
+What this slice will expose, and what to watch for: the dead air while `ask_claude` runs;
+whether rmcp's client request timeout cuts off a slow tool call; and how badly
+`gpt-4o-transcribe` mangles project names and paths on the way in.
+
+### Second path, once the first proves out: B2 + D (the loopback bridge)
+
+This is where the push direction lives, and where this repository finally does change.
+
+- New `bridge.rs`: hyper server on `127.0.0.1`, port and token written to
+  `%APPDATA%\AiDesktopCompanion\bridge.json`, endpoints per §3 B2, off by default behind a
+  settings toggle.
+- Frontend: a listener in `AssistantMode.vue` for `bridge:say-in-call`, injecting into the
+  live realtime session.
+- Rob side: a stdio MCP shim translating MCP tool calls into HTTP calls against it.
+
+**Effort: 1 to 1.5 days in this repository** (Rust plus a small frontend listener plus a
+settings field), on top of an existing server pattern.
+
+Start with `POST /speak`, `POST /notify` and `POST /say-in-call`. Those three are pure reuse
+of `tts_start`, `busy::start` and the realtime data channel, they carry no security weight
+beyond the token, and they deliver the entire "Claude Code speaks up when a background job
+finishes" story on their own.
+
+### Third, only if the first two land: polish
+
+Supervisor filler line and answer streaming (§4); `ask_user` in the Quick Actions window
+(§5); persisted Assistant Mode conversations; wake word.
+
+### Explicitly not recommended
+
+- **C** - the companion should not own Claude Code's lifecycle.
+- **B1** - an in-process rmcp MCP server buys nothing over B2 and costs axum, a fixed port,
+  a single-instance guard and MCP protocol code in Rust.
+- **F2** as the *first* step - it is genuinely cheap here (2-4 hours) but it front-loads real
+  work onto the Rob side (an OpenAI-compatible completions endpoint) to prove the same thing
+  F1 proves for free. Revisit it if `ask_claude`-as-a-tool turns out to be too indirect.
+
+---
+
+## 7. Things that will fight this architecture
+
+Flagged bluntly, because they will each cost an afternoon if discovered late.
+
+1. **CSP allows `http://127.0.0.1` but not `ws://127.0.0.1`.** SSE and fetch are fine.
+   A WebSocket needs edits to both `csp` and `devCsp` in `tauri.conf.json` or the request is
+   silently blocked.
+2. **The existing loopback server uses an ephemeral port** (`127.0.0.1:0`). A bridge needs a
+   discovery file or a fixed configurable port.
+3. **No single-instance guard.** Two copies of the app would fight over a fixed bridge port.
+   `tauri-plugin-single-instance` if a fixed port is chosen.
+4. **Security.** A loopback server that can speak, type into whatever window has focus, and
+   screenshot the desktop is a local privilege surface. Bearer token, loopback bind, reject
+   requests with an `Origin` header, no CORS headers, off by default. Not optional.
+5. **`insert_text_into_focused_app` is genuinely dangerous to expose.** It sets the clipboard,
+   sends Ctrl+V to whatever is focused *right now*, and restores the clipboard afterwards.
+   Handing that to an agent means it can type into whatever Alex happens to be looking at,
+   including a password field or a half-written mail. Gate it: confirmation, or only permit
+   it while the popup or an active call is the current context. `refocus_previous_app` calls
+   `SetForegroundWindow` on a stored HWND, with the same class of problem.
+6. **The `generate_handler!` list in `lib.rs` is the whole Rust/JS contract.** Every new
+   frontend-visible capability needs a line there.
+7. **The Quick Actions window is never created or destroyed at runtime** - `popup.ts` only
+   toggles visibility. Any `ask_user` UI must obey the same rule, on this window or a new
+   statically declared one.
+8. **`rmcp` is client-only** in this build. Anything needing an MCP *server* is a dependency
+   and feature change, which is the main argument for the external-shim shape.
+9. **`chat_complete` hardcodes the OpenAI URL** - there is no base-URL setting for the Prompt
+   or supervisor path, unlike STT and TTS.
+10. **Realtime limits.** `MAX_TOOL_ROUNDS = 6`; `idle_timeout_ms` is capped at 30 s by the
+    API and a rejected `session.update` **discards every other setting with it**; the voice is
+    baked into the ephemeral token and cannot change once audio has been produced.
+11. **Command Mode single-flight plus a 120 s kill.** Any hook-based path must `Start-Process`
+    to detach, or slow answers get killed and `C` stays blocked.
+12. **WebView2 fragility (#14).** `webview_health.rs` exists because the WebView2 process
+    fails in the wild. An always-on call makes that a routine failure rather than a rare one.
+13. **Transcription quality feeds tool arguments.** Spoken project names, file paths and
+    ticket ids will arrive mangled from `gpt-4o-transcribe`. Any tool taking an identifier
+    needs fuzzy resolution on the Claude Code side.


### PR DESCRIPTION
Started as a read-only design assessment of how AiDesktopCompanion could become the voice front-end for a live Claude Code session, then turned into fixing what testing exposed.

## The design note

`specs/ClaudeCode_Integration_options.md` enumerates the realistic integration architectures with effort estimates. The key finding: **Assistant Mode already has a supervisor escalation seam** - a text-in/text-out hole in the middle of a live voice call, already wired to mic, speaker, transcript and history. Anything that can answer a string can be the brain of the call, so the recommended first step costs nothing in this repo: register a stdio MCP shim and let the existing MCP wiring carry it.

Section 1.2.1 documents the tool-routing gate, which is easy to get wrong: **MCP tools and the supervisor are mutually exclusive for the realtime model.** Turning the supervisor on replaces the MCP tools with a single `consult_supervisor` rather than adding to them.

## Fixes found by using it

- **`b1a4e8a`** - "Enable MCP tools" and "Use supervisor agent" live on `ui`, not `session`, so the persist watcher never fired for them. Both reset to off on every start, so the voice session silently came up with no tools. Also: `onWarn` now surfaces on the panel instead of vanishing as a toast, and the tools badge is read back from the server's `session.updated` echo rather than reported optimistically before send.
- **`5d25c50`** - `mcp_connect` dropped the map lock between the "already connected" check and the insert, so two concurrent calls both spawned a child and the second overwrote the first. Dropping an rmcp `RunningService` does not stop it, so the displaced one survived as an unreachable orphan. Observed spawning two copies of a stdio server 23ms apart.
- **`59a08be`** - the note telling the realtime model which tool arrangement it is in was interpolated into the default instructions only, so setting custom instructions silently dropped it. It is now composed for all four states and appended rather than replaced.
- **`58b61fb`** - the Realtime API allows one response at a time. A tool call taking tens of seconds leaves the mic live, so server VAD could open its own response and the `response.create` carrying the tool result was rejected and dropped - the tool had run and nothing ever spoke the answer. All four sites now queue.
- **`b30101a`** - push-to-talk never consulted `micMode`, so releasing the key waited out `silence_duration_ms` (4.2s at the configured default) before the model would answer. Server VAD is now off in PTT and the turn is committed on release, with barge-in and the hold cap handled explicitly.

## Additions

- **`2a00b35`** - Copy button for the realtime event log.
- **`28b6305`** - hold-to-talk button on the call pill, shown only in push-to-talk, with pointer capture so releasing off-window still ends the turn.
- **`7bcaa3e`** - the pill now appears while dialling with a pulsing ring, plus CEPT ringback and a connect beep, scheduled on the audio clock so a hidden window's throttled timers cannot make it stutter. On by default with a switch.

## Verification

`vue-tsc -b` clean, `cargo check` clean, `cargo test --lib` 15 passed (2 new). Manually exercised end to end against a live Claude Code MCP bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)