### PR TITLE
fix(assistant): stop billing for muted silence, and report what a call costs

### DIFF
--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -39,6 +39,29 @@ const transcript = computed<Array<{ role: string, content: string }>>(
 
 const micEnabled = computed(() => (realtime as any).micEnabled?.value !== false)
 
+// Token totals for the session, and what they are worth. Kept after the call
+// ends: the cost is what people look at once it is over.
+const usage = computed(() => (realtime as any).usage?.totals?.value ?? null)
+const usageCost = computed<string | null>(() => {
+  const u: any = (realtime as any).usage
+  if (!u) return null
+  return u.formatUsd(u.estimatedUsd.value)
+})
+const usageTooltip = computed(() => {
+  const u = usage.value
+  if (!u) return ''
+  const rounded = (n: number) => n.toLocaleString()
+  return [
+    `Audio in ${rounded(u.audioIn)} (+${rounded(u.audioInCached)} cached)`,
+    `Audio out ${rounded(u.audioOut)}`,
+    `Text in ${rounded(u.textIn)} (+${rounded(u.textInCached)} cached)`,
+    `Text out ${rounded(u.textOut)}`,
+    `${u.responses} responses`,
+    '',
+    `Estimate only, from rates checked ${(realtime as any).usage?.ratesChecked}. Tokens are exact.`,
+  ].join('\n')
+})
+
 function toggleMic() {
   ;(realtime as any).setMicEnabled?.(!micEnabled.value)
 }
@@ -575,6 +598,11 @@ onBeforeUnmount(() => {
         <span v-if="ui.connected" class="badge" title="Session length. Realtime audio is billed per audio token, so a longer call costs more - though a muted microphone sends nothing and costs nothing.">
           {{ elapsedLabel }}
         </span>
+        <span
+          v-if="usage && usage.responses > 0"
+          class="badge"
+          :title="usageTooltip"
+        >~{{ usageCost ?? 'n/a' }}</span>
         <span class="spacer"></span>
         <span class="badge">Tools {{ (realtime as any)?.status?.value?.toolsCount ?? 0 }}</span>
         <span class="badge" v-if="ui.useSupervisor">

--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -112,8 +112,9 @@ function onPttDown() {
 
 function onPttUp() { if (ui.connected && session.micMode === 'ptt') stopTalking() }
 
-// Realtime audio is billed by the minute, so how long a session has been open
-// is the number worth putting on screen.
+// Realtime audio is billed per audio token - roughly one per 100ms heard and
+// one per 50ms spoken - so time on the call is the closest thing to a running
+// meter, and the number worth putting on screen.
 const elapsedSeconds = ref(0)
 let elapsedTimer: any = 0
 
@@ -287,8 +288,8 @@ const session = reactive({
   // 'open' is the previous behaviour and stays the default; push-to-talk is
   // opt-in because it needs a hotkey or a held button to be usable.
   micMode: 'open' as 'open' | 'ptt',
-  // A live session bills per minute with an open microphone, so a forgotten
-  // window closes itself rather than running until somebody notices.
+  // An open microphone keeps feeding billable audio to the model, so a
+  // forgotten window closes itself rather than running until somebody notices.
   autoCloseMinutes: 2,
   // Ringback while connecting and a beep when the call is up. On by default:
   // the connect happens from a global hotkey with the window usually hidden, so
@@ -571,7 +572,7 @@ onBeforeUnmount(() => {
         </span>
         <span v-if="ui.connected && !micEnabled" class="badge warn">Mic muted</span>
         <span v-else-if="ui.connected && session.micMode === 'ptt'" class="badge ok">Mic open</span>
-        <span v-if="ui.connected" class="badge" title="Session length - realtime audio is billed per minute">
+        <span v-if="ui.connected" class="badge" title="Session length. Realtime audio is billed per audio token, so a longer call costs more - though a muted microphone sends nothing and costs nothing.">
           {{ elapsedLabel }}
         </span>
         <span class="spacer"></span>
@@ -654,6 +655,10 @@ onBeforeUnmount(() => {
             Hold the button above. Set a hotkey in Settings &rsaquo; General to hold from any application.
           </template>
         </p>
+        <p class="field-hint">
+          The microphone is captured for the whole session either way, so Windows shows its
+          recording indicator until you hang up. Nothing is sent while muted or between holds.
+        </p>
       </div>
 
       <div class="field">
@@ -718,7 +723,7 @@ onBeforeUnmount(() => {
       <div class="field">
         <label class="field-label">Close session after</label>
         <input class="input" type="number" min="0" step="1" v-model.number="session.autoCloseMinutes" @change="syncSession" />
-        <p class="field-hint">Minutes of silence before the session disconnects. 0 never closes - but an open session holds a live microphone and bills per minute.</p>
+        <p class="field-hint">Minutes of silence before the session disconnects. 0 never closes - but an open microphone keeps sending billable audio for as long as the session lasts.</p>
       </div>
     </div>
 

--- a/app/src/composables/useAssistantRealtime.ts
+++ b/app/src/composables/useAssistantRealtime.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
+import { useRealtimeUsage } from './useRealtimeUsage'
 
 // Where the SDP offer is exchanged for an answer. The beta endpoint this used
 // to post to, `POST /v1/realtime?model=...`, was removed with the rest of the
@@ -154,6 +155,14 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
   // each utterance in isolation, and the panel renders it so a session is
   // readable rather than something you had to be listening to.
   const history = ref<HistoryTurn[]>([])
+
+  // Token and cost accounting. The numbers arrive on every response.done and
+  // were previously thrown away, so the most expensive thing this app does was
+  // also the only thing that reported nothing about what it cost.
+  const usage = useRealtimeUsage()
+  // Logged once per session rather than per response: if the usage shape ever
+  // changes, one line says so instead of several hundred.
+  let warnedAboutUsageShape = false
 
   function log(msg: string) {
     try { opts.onLog?.(msg) } catch {}
@@ -442,6 +451,12 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
         send(queued)
       }
 
+      const counted = usage.addResponse(parsed?.response?.usage)
+      if (!counted && !warnedAboutUsageShape) {
+        warnedAboutUsageShape = true
+        log('[usage] response.done carried no recognisable usage block; totals will read low')
+      }
+
       const output = Array.isArray(parsed?.response?.output) ? parsed.response.output : []
       const calls = output.filter((o: any) => o?.type === 'function_call')
       if (calls.length) {
@@ -467,6 +482,10 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       pendingResponse = null
       toolRounds = 0
       connected = false
+      // Rates depend on the model, so the totals are told which one before the
+      // first response arrives.
+      usage.reset(params.model)
+      warnedAboutUsageShape = false
 
       const pc = new RTCPeerConnection({
         iceServers: [
@@ -934,5 +953,7 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
 
   // The transcript deliberately survives disconnect, so the last conversation
   // is still readable after the session ends; `connect` clears it.
-  return { connect, disconnect, attachAudioElement, updateSession, setMicEnabled, startTalking, stopTalking, micEnabled, status: statusRef, transcript: history }
+  // The totals deliberately survive disconnect, like the transcript: what the
+  // call cost is worth reading after it ends, which is when anyone looks.
+  return { connect, disconnect, attachAudioElement, updateSession, setMicEnabled, startTalking, stopTalking, micEnabled, status: statusRef, transcript: history, usage }
 }

--- a/app/src/composables/useAssistantRealtime.ts
+++ b/app/src/composables/useAssistantRealtime.ts
@@ -106,6 +106,10 @@ export interface HistoryTurn { role: 'user' | 'assistant' | 'tool', content: str
 export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
   const pcRef = ref<RTCPeerConnection | null>(null)
   const micStreamRef = ref<MediaStream | null>(null)
+  // The sender carrying the microphone, and the track to put back on it. Muting
+  // detaches the track from the sender rather than merely disabling it.
+  let micSender: RTCRtpSender | null = null
+  let micTrack: MediaStreamTrack | null = null
   const statusRef = ref<{ toolsCount: number, supervisor: boolean, voice?: string, silenceMs?: number, idleMs?: number }>({ toolsCount: 0, supervisor: false })
   let remoteAudioEl: HTMLAudioElement | null = document.createElement('audio')
   let currentUseSupervisor = false
@@ -159,7 +163,8 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
    * Restart the inactivity countdown.
    *
    * Called whenever either side says something. An open realtime session holds
-   * a live microphone and bills by the minute, so walking away from the window
+   * a live microphone and bills for the audio flowing through it, so walking
+   * away from the window
    * should not keep costing money.
    */
   function resetAutoClose() {
@@ -501,7 +506,12 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
 
       // Capture microphone and add as sendonly track
       const mic = await navigator.mediaDevices.getUserMedia({ audio: true })
-      mic.getAudioTracks().forEach((t) => pc.addTrack(t, mic))
+      // Keep the sender: muting detaches the track from it, which is what
+      // actually stops audio leaving. See `setMicEnabled`.
+      mic.getAudioTracks().forEach((t) => {
+        const sender = pc.addTrack(t, mic)
+        if (!micSender) { micSender = sender; micTrack = t }
+      })
       // In push-to-talk the microphone must be closed the instant it exists,
       // not once the first session.update lands.
       const startMuted = params.micMode === 'ptt'
@@ -784,6 +794,8 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
       micStreamRef.value?.getTracks().forEach(t => t.stop())
     } catch {}
     micStreamRef.value = null
+    micSender = null
+    micTrack = null
     try {
       const pc = pcRef.value
       if (pc) {
@@ -807,16 +819,34 @@ export function useAssistantRealtime(opts: AssistantRealtimeOptions) {
   /**
    * Mute or unmute the microphone for the rest of the session.
    *
-   * Disables the track rather than stopping it: a stopped track cannot be
-   * restarted on the same connection, and re-negotiating just to unmute would
-   * drop the conversation.
+   * Two things happen, and both are needed.
+   *
+   * `track.enabled = false` takes effect immediately but does not stop the
+   * sender: WebRTC keeps transmitting, just silence. The Realtime API bills
+   * audio input at a token per 100ms, so a muted microphone left attached is
+   * paying for its own silence - which in push-to-talk is most of the call.
+   * Detaching the track from the sender with `replaceTrack(null)` is what
+   * actually stops audio leaving, and it needs no renegotiation, so the call
+   * survives it.
+   *
+   * The track itself is deliberately left running. Stopping it would clear the
+   * OS microphone indicator, but re-acquiring on the next key press costs a
+   * few hundred milliseconds of `getUserMedia` and would clip the start of
+   * whatever the user was already saying. Push-to-talk is judged on exactly
+   * that responsiveness, so the indicator stays lit for the session and the UI
+   * says so rather than pretending otherwise.
    */
   function setMicEnabled(enabled: boolean) {
     micEnabled.value = enabled
     try {
       micStreamRef.value?.getAudioTracks().forEach((t) => { t.enabled = enabled })
     } catch {}
-    log(enabled ? '[mic] unmuted' : '[mic] muted')
+    try {
+      // Best-effort: a failure here means silence is still being sent, which is
+      // a billing annoyance, never a reason to break the call.
+      void micSender?.replaceTrack(enabled ? micTrack : null)?.catch?.(() => {})
+    } catch {}
+    log(enabled ? '[mic] unmuted' : '[mic] muted, no longer transmitting')
   }
 
   /**

--- a/app/src/composables/useRealtimeUsage.ts
+++ b/app/src/composables/useRealtimeUsage.ts
@@ -1,0 +1,161 @@
+import { ref } from 'vue'
+
+/**
+ * Token and cost accounting for a Realtime session.
+ *
+ * Every `response.done` carries a usage block, split by modality and by cached
+ * versus fresh input. It was previously discarded, so a call that had cost real
+ * money reported nothing at all - and realtime audio is the most expensive
+ * thing this app does.
+ *
+ * Tokens are counted exactly, from what the API reports. Money is an estimate
+ * and is labelled as one: the rates below are correct at the time of writing
+ * but are not fetched from anywhere, and OpenAI has cut realtime pricing
+ * repeatedly. `RATES_CHECKED` is what tells you how far to trust the figure.
+ */
+
+/** When the rate table below was last verified against OpenAI's pricing page. */
+export const RATES_CHECKED = '2026-08-25'
+
+/** USD per million tokens. */
+interface ModelRates {
+  audioIn: number
+  audioInCached: number
+  audioOut: number
+  textIn: number
+  textInCached: number
+  textOut: number
+}
+
+/**
+ * Rates by model prefix, longest match first.
+ *
+ * Keyed on prefix because OpenAI ships dated snapshots behind moving aliases
+ * (`gpt-realtime-2.1-2026-...`), and a table of exact ids would silently miss
+ * every one of them and report a call as free.
+ *
+ * Audio, cached audio and text rates are taken from OpenAI's published pricing.
+ * `textInCached` is the one inferred figure - cached text is priced at a tenth
+ * of fresh text, matching the ratio used elsewhere - and it moves the total by
+ * almost nothing, because audio dominates a voice call by two orders of
+ * magnitude.
+ */
+const RATE_TABLE: Array<{ prefix: string, rates: ModelRates }> = [
+  {
+    prefix: 'gpt-realtime-2.1-mini',
+    rates: { audioIn: 10, audioInCached: 0.3, audioOut: 20, textIn: 0.6, textInCached: 0.06, textOut: 2.4 },
+  },
+  {
+    prefix: 'gpt-realtime-2.1',
+    rates: { audioIn: 32, audioInCached: 0.4, audioOut: 64, textIn: 4, textInCached: 0.4, textOut: 16 },
+  },
+  {
+    prefix: 'gpt-realtime-2',
+    rates: { audioIn: 32, audioInCached: 0.4, audioOut: 64, textIn: 4, textInCached: 0.4, textOut: 16 },
+  },
+  {
+    prefix: 'gpt-realtime',
+    rates: { audioIn: 32, audioInCached: 0.4, audioOut: 64, textIn: 4, textInCached: 0.4, textOut: 16 },
+  },
+]
+
+function ratesFor(model?: string): ModelRates | null {
+  const m = String(model || '')
+  // Longest prefix wins, so the mini is never charged at the flagship rate.
+  const sorted = [...RATE_TABLE].sort((a, b) => b.prefix.length - a.prefix.length)
+  for (const entry of sorted) {
+    if (m.startsWith(entry.prefix)) return entry.rates
+  }
+  return null
+}
+
+export interface UsageTotals {
+  audioIn: number
+  audioInCached: number
+  audioOut: number
+  textIn: number
+  textInCached: number
+  textOut: number
+  responses: number
+}
+
+function emptyTotals(): UsageTotals {
+  return { audioIn: 0, audioInCached: 0, audioOut: 0, textIn: 0, textInCached: 0, textOut: 0, responses: 0 }
+}
+
+function num(v: any): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+}
+
+export function useRealtimeUsage() {
+  const totals = ref<UsageTotals>(emptyTotals())
+  /** null when the session's model has no known rates. */
+  const estimatedUsd = ref<number | null>(0)
+  const model = ref<string>('')
+
+  function reset(nextModel?: string) {
+    totals.value = emptyTotals()
+    model.value = nextModel || ''
+    estimatedUsd.value = ratesFor(model.value) ? 0 : null
+  }
+
+  function recompute() {
+    const rates = ratesFor(model.value)
+    if (!rates) { estimatedUsd.value = null; return }
+    const t = totals.value
+    estimatedUsd.value =
+      (t.audioIn * rates.audioIn
+        + t.audioInCached * rates.audioInCached
+        + t.audioOut * rates.audioOut
+        + t.textIn * rates.textIn
+        + t.textInCached * rates.textInCached
+        + t.textOut * rates.textOut) / 1_000_000
+  }
+
+  /**
+   * Fold one `response.done` usage block into the running totals.
+   *
+   * Cached input is reported inside the input totals rather than alongside
+   * them, so it is subtracted out before the uncached remainder is charged at
+   * the full rate - counting both would roughly double the input cost.
+   */
+  function addResponse(usage: any): boolean {
+    if (!usage || typeof usage !== 'object') return false
+
+    const inDetails = usage.input_token_details
+    const outDetails = usage.output_token_details
+    // Reported as false rather than counted as zero. Silently showing $0.00 for
+    // a call that cost money is worse than showing nothing, and this is exactly
+    // the shape that would change under us.
+    if (!inDetails && !outDetails) return false
+
+    const cached = (inDetails && inDetails.cached_tokens_details) || {}
+
+    const audioInTotal = num(inDetails?.audio_tokens)
+    const textInTotal = num(inDetails?.text_tokens)
+    const audioInCached = Math.min(num(cached.audio_tokens), audioInTotal)
+    const textInCached = Math.min(num(cached.text_tokens), textInTotal)
+
+    const t = { ...totals.value }
+    t.audioIn += Math.max(0, audioInTotal - audioInCached)
+    t.audioInCached += audioInCached
+    t.textIn += Math.max(0, textInTotal - textInCached)
+    t.textInCached += textInCached
+    t.audioOut += num(outDetails?.audio_tokens)
+    t.textOut += num(outDetails?.text_tokens)
+    t.responses += 1
+    totals.value = t
+
+    recompute()
+    return true
+  }
+
+  /** "$0.0412", or null when the model has no known rates. */
+  function formatUsd(value: number | null): string | null {
+    if (value === null) return null
+    if (value < 0.01) return `$${value.toFixed(4)}`
+    return `$${value.toFixed(2)}`
+  }
+
+  return { totals, estimatedUsd, reset, addResponse, formatUsd, ratesChecked: RATES_CHECKED }
+}


### PR DESCRIPTION
Follow-up to #15, closing out the remaining items from the Assistant Mode handoff.

## `c214ff8` - muted microphone was still transmitting

Muting only set `track.enabled = false`, which stops the audio but not the sender - WebRTC keeps transmitting silence. Realtime bills audio input at roughly a token per 100ms, so a muted microphone left attached to its sender pays for its own silence, and in push-to-talk that is most of the call. Muting now also detaches the track with `replaceTrack(null)`, which needs no renegotiation.

The track is deliberately left running. Stopping it would clear the OS recording indicator, but re-acquiring on the next key press costs a few hundred milliseconds of `getUserMedia` and would clip the start of whatever was already being said - and push-to-talk is judged on exactly that responsiveness. The UI now says the microphone is captured for the whole session rather than implying otherwise.

Four places also claimed realtime audio is "billed per minute". It is billed per audio token. Reworded to match - which is what makes muting worth anything.

## `7bdc2d8` - usage and cost reporting

Every `response.done` carries a usage block split by modality and by cached versus fresh input. It was discarded, so the most expensive thing this app does was the only thing reporting nothing about what it cost.

Tokens are exact; money is an estimate and says so. Rates live in a local table keyed on **model prefix**, because OpenAI ships dated snapshots behind moving aliases and a table of exact ids would miss every one and report a call as free. Cached input is reported *inside* the input totals, so it is subtracted before the remainder is charged at full rate - counting both would roughly double the input cost. Verified against the documented example: 476 audio in with 384 cached bills 92 fresh.

A `response.done` with no recognisable usage block is logged once per session rather than counted as zero: silently showing $0.00 for a call that cost money is worse than showing nothing.

## Verification

`vue-tsc -b` clean. Pricing checked against OpenAI's published rates rather than assumed (`gpt-realtime-2.1` $32/$64 per 1M audio in/out, mini $10/$20, cached audio $0.30) and the `usage` shape checked against the documented example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)