### PR TITLE
feat(app): configurable text insertion methods with clipboard bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,10 @@ Release notes:
   - Speech-to-Text push‑to‑talk (hold S / mouse, release to transcribe)
   - Image capture overlay
 - MCP server connections (tool discovery + tool calls from chat)
-- Aggressive clipboard copy‑restore for reliable text insertion, or an opt‑in keystroke mode
-  (Settings → General → Text insertion) that types the result and leaves the clipboard untouched
+- Five text-insertion methods (Settings → General → Text insertion): Ctrl + V, Ctrl + Shift + V and
+  Shift + Insert paste through an aggressive clipboard copy‑restore with a tunable delay, keystroke
+  mode types the result without touching the clipboard, and "do not insert" only puts it there.
+  A separate setting decides whether the clipboard is restored afterwards or keeps the result
 - Auto‑sizing popup and robust window focus management
 
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ Release notes:
   - Speech-to-Text push‑to‑talk (hold S / mouse, release to transcribe)
   - Image capture overlay
 - MCP server connections (tool discovery + tool calls from chat)
-- Aggressive clipboard copy‑restore for reliable text insertion
+- Aggressive clipboard copy‑restore for reliable text insertion, or an opt‑in keystroke mode
+  (Settings → General → Text insertion) that types the result and leaves the clipboard untouched
 - Auto‑sizing popup and robust window focus management
 
 

--- a/app/src-tauri/src/config.rs
+++ b/app/src-tauri/src/config.rs
@@ -128,23 +128,77 @@ pub fn get_select_all_capture_mode() -> String {
   normalize_select_all_capture_mode(raw).to_string()
 }
 
-/// Normalize an `insert_mode` value to one of the two supported modes,
-/// defaulting to `"clipboard"`.
+/// Longest paste delay we will honour. Past a couple of seconds the user is
+/// staring at a frozen popup and would rather see the paste fail.
+pub const MAX_PASTE_DELAY_MS: u64 = 2000;
+
+/// Default wait between sending the paste combo and restoring the clipboard.
+/// Long enough for the target application to have read the clipboard; short
+/// enough not to be noticeable.
+pub const DEFAULT_PASTE_DELAY_MS: u64 = 120;
+
+/// Normalize an `insert_mode` value to one of the five supported modes,
+/// defaulting to `"ctrl_v"`.
+///
+/// `"clipboard"` is accepted as an alias for `"ctrl_v"`: it was the value of
+/// the two-way toggle this setting replaced.
 pub fn normalize_insert_mode(value: &str) -> &'static str {
   match value.trim() {
+    "ctrl_shift_v" => "ctrl_shift_v",
+    "shift_insert" => "shift_insert",
     "keystrokes" => "keystrokes",
-    _ => "clipboard",
+    "none" => "none",
+    _ => "ctrl_v",
   }
 }
 
-/// How results are put back into the focused application: `"clipboard"` (set
-/// the clipboard, send Ctrl+V, then restore the previous contents - the
-/// default) or `"keystrokes"` (simulate key presses and never touch the
-/// clipboard).
+/// How results are put back into the focused application.
+///
+/// `"ctrl_v"` (the default), `"ctrl_shift_v"` and `"shift_insert"` all go
+/// through the clipboard and differ only in the combo they send - the latter
+/// two are what terminals and consoles answer to. `"keystrokes"` types the
+/// text and never opens the clipboard. `"none"` inserts nothing, which is only
+/// useful together with `clipboard_handling = "copy_to_clipboard"`.
 pub fn get_insert_mode() -> String {
   let v = load_settings_json();
   let raw = v.get("insert_mode").and_then(|x| x.as_str()).unwrap_or("");
   normalize_insert_mode(raw).to_string()
+}
+
+/// Normalize a `clipboard_handling` value, defaulting to `"dont_modify"`.
+pub fn normalize_clipboard_handling(value: &str) -> &'static str {
+  match value.trim() {
+    "copy_to_clipboard" => "copy_to_clipboard",
+    _ => "dont_modify",
+  }
+}
+
+/// What the clipboard looks like once an insertion has finished:
+/// `"dont_modify"` (the default) puts back whatever was there before, and
+/// `"copy_to_clipboard"` deliberately leaves the inserted text on it.
+pub fn get_clipboard_handling() -> String {
+  let v = load_settings_json();
+  let raw = v
+    .get("clipboard_handling")
+    .and_then(|x| x.as_str())
+    .unwrap_or("");
+  normalize_clipboard_handling(raw).to_string()
+}
+
+/// Clamp a paste delay to something a human would want to sit through.
+pub fn normalize_paste_delay_ms(value: u64) -> u64 {
+  value.min(MAX_PASTE_DELAY_MS)
+}
+
+/// Milliseconds to wait after sending the paste combo before restoring the
+/// clipboard. Too short and the target application reads the restored contents
+/// instead of the result, pasting the wrong text.
+pub fn get_paste_delay_ms() -> u64 {
+  let v = load_settings_json();
+  match v.get("paste_delay_ms").and_then(|x| x.as_u64()) {
+    Some(ms) => normalize_paste_delay_ms(ms),
+    None => DEFAULT_PASTE_DELAY_MS,
+  }
 }
 
 // Speech-To-Text engine selection: "openai" (default) or "local"
@@ -295,6 +349,14 @@ pub fn save_settings(map: serde_json::Value) -> Result<String, String> {
     let normalized = normalize_insert_mode(mode);
     obj.insert("insert_mode".to_string(), serde_json::Value::String(normalized.to_string()));
   }
+  if let Some(mode) = map.get("clipboard_handling").and_then(|x| x.as_str()) {
+    let normalized = normalize_clipboard_handling(mode);
+    obj.insert("clipboard_handling".to_string(), serde_json::Value::String(normalized.to_string()));
+  }
+  if let Some(ms) = map.get("paste_delay_ms").and_then(|x| x.as_u64()) {
+    let clamped = normalize_paste_delay_ms(ms);
+    obj.insert("paste_delay_ms".to_string(), serde_json::Value::Number(serde_json::Number::from(clamped)));
+  }
   // Persist the floating busy indicator toggle
   if let Some(flag) = map.get("show_busy_indicator").and_then(|x| x.as_bool()) { obj.insert("show_busy_indicator".to_string(), serde_json::Value::Bool(flag)); }
   // Persist global system prompt
@@ -444,5 +506,50 @@ pub fn clear_conversations() -> Result<String, String> {
     Ok(path.to_string_lossy().to_string())
   } else {
     Err("Unsupported platform for config path".into())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn insert_mode_accepts_every_supported_value() {
+    for mode in ["ctrl_v", "ctrl_shift_v", "shift_insert", "keystrokes", "none"] {
+      assert_eq!(normalize_insert_mode(mode), mode);
+    }
+  }
+
+  #[test]
+  fn insert_mode_tolerates_surrounding_whitespace() {
+    assert_eq!(normalize_insert_mode("  keystrokes \n"), "keystrokes");
+  }
+
+  #[test]
+  fn insert_mode_falls_back_to_ctrl_v() {
+    assert_eq!(normalize_insert_mode(""), "ctrl_v");
+    assert_eq!(normalize_insert_mode("nonsense"), "ctrl_v");
+    assert_eq!(normalize_insert_mode("Keystrokes"), "ctrl_v");
+  }
+
+  #[test]
+  fn insert_mode_maps_the_retired_clipboard_value_to_ctrl_v() {
+    assert_eq!(normalize_insert_mode("clipboard"), "ctrl_v");
+  }
+
+  #[test]
+  fn clipboard_handling_defaults_to_leaving_the_clipboard_alone() {
+    assert_eq!(normalize_clipboard_handling("copy_to_clipboard"), "copy_to_clipboard");
+    assert_eq!(normalize_clipboard_handling("dont_modify"), "dont_modify");
+    assert_eq!(normalize_clipboard_handling(""), "dont_modify");
+    assert_eq!(normalize_clipboard_handling("whatever"), "dont_modify");
+  }
+
+  #[test]
+  fn paste_delay_is_clamped_to_the_ceiling() {
+    assert_eq!(normalize_paste_delay_ms(0), 0);
+    assert_eq!(normalize_paste_delay_ms(120), 120);
+    assert_eq!(normalize_paste_delay_ms(MAX_PASTE_DELAY_MS), MAX_PASTE_DELAY_MS);
+    assert_eq!(normalize_paste_delay_ms(60_000), MAX_PASTE_DELAY_MS);
   }
 }

--- a/app/src-tauri/src/config.rs
+++ b/app/src-tauri/src/config.rs
@@ -128,6 +128,25 @@ pub fn get_select_all_capture_mode() -> String {
   normalize_select_all_capture_mode(raw).to_string()
 }
 
+/// Normalize an `insert_mode` value to one of the two supported modes,
+/// defaulting to `"clipboard"`.
+pub fn normalize_insert_mode(value: &str) -> &'static str {
+  match value.trim() {
+    "keystrokes" => "keystrokes",
+    _ => "clipboard",
+  }
+}
+
+/// How results are put back into the focused application: `"clipboard"` (set
+/// the clipboard, send Ctrl+V, then restore the previous contents - the
+/// default) or `"keystrokes"` (simulate key presses and never touch the
+/// clipboard).
+pub fn get_insert_mode() -> String {
+  let v = load_settings_json();
+  let raw = v.get("insert_mode").and_then(|x| x.as_str()).unwrap_or("");
+  normalize_insert_mode(raw).to_string()
+}
+
 // Speech-To-Text engine selection: "openai" (default) or "local"
 pub fn get_stt_engine_from_settings_or_env() -> String {
   let v = load_settings_json();
@@ -270,6 +289,11 @@ pub fn save_settings(map: serde_json::Value) -> Result<String, String> {
   if let Some(mode) = map.get("select_all_capture_mode").and_then(|x| x.as_str()) {
     let normalized = normalize_select_all_capture_mode(mode);
     obj.insert("select_all_capture_mode".to_string(), serde_json::Value::String(normalized.to_string()));
+  }
+  // Persist how results are inserted into the focused app
+  if let Some(mode) = map.get("insert_mode").and_then(|x| x.as_str()) {
+    let normalized = normalize_insert_mode(mode);
+    obj.insert("insert_mode".to_string(), serde_json::Value::String(normalized.to_string()));
   }
   // Persist the floating busy indicator toggle
   if let Some(flag) = map.get("show_busy_indicator").and_then(|x| x.as_bool()) { obj.insert("show_busy_indicator".to_string(), serde_json::Value::Bool(flag)); }

--- a/app/src-tauri/src/quick_actions.rs
+++ b/app/src-tauri/src/quick_actions.rs
@@ -187,8 +187,21 @@ pub fn insert_prompt_text(app: tauri::AppHandle, text: String) -> Result<(), Str
   Ok(())
 }
 
+/// Put `text` into the application that had focus before the popup appeared.
+///
+/// Two routes, chosen by the `insert_mode` setting:
+///
+/// - `"clipboard"` (default) - save the clipboard, set it to `text`, send
+///   Ctrl+V, then put the old contents back. Fast and exact for any length of
+///   text, but it briefly owns the clipboard and shows up in clipboard history.
+/// - `"keystrokes"` - type `text` as synthetic key presses and never open the
+///   clipboard. `safe_mode` has nothing to guard in this route, so it is
+///   ignored: there is no copy-restore cycle to skip.
 #[tauri::command]
 pub fn insert_text_into_focused_app(text: String, safe_mode: Option<bool>) -> Result<(), String> {
+  if crate::config::get_insert_mode() == "keystrokes" {
+    return crate::utils::type_text(&text);
+  }
   let safe = safe_mode.unwrap_or(false);
   let mut clipboard = Clipboard::new().map_err(|e| format!("clipboard init failed: {e}"))?;
   let previous_text = if !safe { clipboard.get_text().ok() } else { None };

--- a/app/src-tauri/src/quick_actions.rs
+++ b/app/src-tauri/src/quick_actions.rs
@@ -189,28 +189,57 @@ pub fn insert_prompt_text(app: tauri::AppHandle, text: String) -> Result<(), Str
 
 /// Put `text` into the application that had focus before the popup appeared.
 ///
-/// Two routes, chosen by the `insert_mode` setting:
+/// The route is the `insert_mode` setting, and what the clipboard looks like
+/// afterwards is the separate `clipboard_handling` setting:
 ///
-/// - `"clipboard"` (default) - save the clipboard, set it to `text`, send
-///   Ctrl+V, then put the old contents back. Fast and exact for any length of
-///   text, but it briefly owns the clipboard and shows up in clipboard history.
-/// - `"keystrokes"` - type `text` as synthetic key presses and never open the
-///   clipboard. `safe_mode` has nothing to guard in this route, so it is
-///   ignored: there is no copy-restore cycle to skip.
+/// - `"ctrl_v"` (default), `"ctrl_shift_v"`, `"shift_insert"` - set the
+///   clipboard to `text` and send that combo. Exact and instant at any length.
+///   The two non-default combos exist for terminals and consoles, where
+///   Ctrl+V is a control character or bound to something else.
+/// - `"keystrokes"` - type `text` as synthetic key presses. The only route
+///   that never opens the clipboard, so `safe_mode` has no copy-restore cycle
+///   to skip and is ignored.
+/// - `"none"` - insert nothing. Only useful with `"copy_to_clipboard"`, where
+///   together they mean "just put the result on my clipboard".
 #[tauri::command]
 pub fn insert_text_into_focused_app(text: String, safe_mode: Option<bool>) -> Result<(), String> {
-  if crate::config::get_insert_mode() == "keystrokes" {
-    return crate::utils::type_text(&text);
+  let mode = crate::config::get_insert_mode();
+  // When the user wants the result left on the clipboard, the clipboard routes
+  // get there by simply not restoring; the other two have to put it there.
+  let keep_result = crate::config::get_clipboard_handling() == "copy_to_clipboard";
+
+  if mode == "keystrokes" {
+    crate::utils::type_text(&text)?;
+    if keep_result {
+      return copy_text_to_clipboard(text);
+    }
+    return Ok(());
   }
+
+  if mode == "none" {
+    if keep_result {
+      return copy_text_to_clipboard(text);
+    }
+    return Ok(());
+  }
+
   let safe = safe_mode.unwrap_or(false);
   let mut clipboard = Clipboard::new().map_err(|e| format!("clipboard init failed: {e}"))?;
-  let previous_text = if !safe { clipboard.get_text().ok() } else { None };
+  // Nothing to put back if the caller opted out of the copy-restore cycle, or
+  // if the user asked for the result to stay on the clipboard.
+  let previous_text = if safe || keep_result { None } else { clipboard.get_text().ok() };
   let _ = clipboard.set_text(text);
-  {
-    crate::utils::send_ctrl_key('v')?;
+  match mode.as_str() {
+    "ctrl_shift_v" => crate::utils::send_ctrl_shift_key('v')?,
+    "shift_insert" => crate::utils::send_shift_insert()?,
+    _ => crate::utils::send_ctrl_key('v')?,
   }
-  thread::sleep(Duration::from_millis(120));
-  if !safe { if let Some(prev) = previous_text { let _ = clipboard.set_text(prev); } }
+  // Give the target application time to actually read the clipboard. Restore
+  // too early and it pastes the previous contents instead of the result.
+  thread::sleep(Duration::from_millis(crate::config::get_paste_delay_ms()));
+  if let Some(prev) = previous_text {
+    let _ = clipboard.set_text(prev);
+  }
   Ok(())
 }
 

--- a/app/src-tauri/src/utils.rs
+++ b/app/src-tauri/src/utils.rs
@@ -130,3 +130,162 @@ fn send_chord(key: enigo::Key, shift: bool, label: &str) -> Result<(), String> {
     .map_err(|e| format!("ctrl release failed: {e}"));
   click.and(shift_release).and(ctrl_release)
 }
+
+/// One step of a keystroke-mode insertion: a run of literal text, or a
+/// structural key that has no Unicode keystroke of its own.
+///
+/// Synthetic Unicode input has no way to express a line break - sending U+000A
+/// as a character event is silently dropped by most applications, so a
+/// multi-line result would arrive as a single run-on line. Newlines and tabs
+/// therefore have to be lifted out of the text and sent as real key presses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypedSegment {
+  Text(String),
+  Newline,
+  Tab,
+}
+
+/// Split `text` into the segments `type_text` sends, folding `\r\n` and a lone
+/// `\r` into a single newline so Windows-style input does not press Return
+/// twice per line.
+pub fn split_typed_segments(text: &str) -> Vec<TypedSegment> {
+  let mut segments: Vec<TypedSegment> = Vec::new();
+  let mut buf = String::new();
+  let mut chars = text.chars().peekable();
+  while let Some(ch) = chars.next() {
+    match ch {
+      '\r' | '\n' => {
+        // Swallow the '\n' of a "\r\n" pair so it counts as one line break.
+        if ch == '\r' && chars.peek() == Some(&'\n') {
+          chars.next();
+        }
+        if !buf.is_empty() {
+          segments.push(TypedSegment::Text(std::mem::take(&mut buf)));
+        }
+        segments.push(TypedSegment::Newline);
+      }
+      '\t' => {
+        if !buf.is_empty() {
+          segments.push(TypedSegment::Text(std::mem::take(&mut buf)));
+        }
+        segments.push(TypedSegment::Tab);
+      }
+      _ => buf.push(ch),
+    }
+  }
+  if !buf.is_empty() {
+    segments.push(TypedSegment::Text(buf));
+  }
+  segments
+}
+
+/// Type `text` into whatever window currently has focus by simulating key
+/// presses, leaving the clipboard untouched.
+///
+/// The alternative to the clipboard/Ctrl+V insertion path: it costs the user
+/// nothing in clipboard contents or clipboard history, but every newline is a
+/// real Return press, which submits the message in chat-style inputs. That
+/// trade-off is why clipboard insertion stays the default.
+pub fn type_text(text: &str) -> Result<(), String> {
+  use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+  let segments = split_typed_segments(text);
+  if segments.is_empty() {
+    return Ok(());
+  }
+  let mut enigo = Enigo::new(&Settings::default())
+    .map_err(|e| format!("input simulation unavailable: {e}"))?;
+  for segment in segments {
+    match segment {
+      TypedSegment::Text(s) => enigo
+        .text(&s)
+        .map_err(|e| format!("typing text failed: {e}"))?,
+      TypedSegment::Newline => enigo
+        .key(Key::Return, Direction::Click)
+        .map_err(|e| format!("Return failed: {e}"))?,
+      TypedSegment::Tab => enigo
+        .key(Key::Tab, Direction::Click)
+        .map_err(|e| format!("Tab failed: {e}"))?,
+    }
+  }
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{split_typed_segments, TypedSegment};
+
+  fn text(s: &str) -> TypedSegment {
+    TypedSegment::Text(s.to_string())
+  }
+
+  #[test]
+  fn plain_text_is_one_segment() {
+    assert_eq!(split_typed_segments("hello world"), vec![text("hello world")]);
+  }
+
+  #[test]
+  fn empty_text_produces_no_segments() {
+    assert!(split_typed_segments("").is_empty());
+  }
+
+  #[test]
+  fn newlines_become_return_presses() {
+    assert_eq!(
+      split_typed_segments("a\nb"),
+      vec![text("a"), TypedSegment::Newline, text("b")]
+    );
+  }
+
+  #[test]
+  fn crlf_counts_as_a_single_newline() {
+    assert_eq!(
+      split_typed_segments("a\r\nb"),
+      vec![text("a"), TypedSegment::Newline, text("b")]
+    );
+  }
+
+  #[test]
+  fn lone_carriage_return_counts_as_a_newline() {
+    assert_eq!(
+      split_typed_segments("a\rb"),
+      vec![text("a"), TypedSegment::Newline, text("b")]
+    );
+  }
+
+  #[test]
+  fn blank_lines_are_preserved() {
+    assert_eq!(
+      split_typed_segments("a\n\nb"),
+      vec![
+        text("a"),
+        TypedSegment::Newline,
+        TypedSegment::Newline,
+        text("b")
+      ]
+    );
+  }
+
+  #[test]
+  fn leading_and_trailing_newlines_are_preserved() {
+    assert_eq!(
+      split_typed_segments("\na\n"),
+      vec![TypedSegment::Newline, text("a"), TypedSegment::Newline]
+    );
+  }
+
+  #[test]
+  fn tabs_become_tab_presses() {
+    assert_eq!(
+      split_typed_segments("a\tb"),
+      vec![text("a"), TypedSegment::Tab, text("b")]
+    );
+  }
+
+  #[test]
+  fn non_ascii_text_survives_intact() {
+    assert_eq!(
+      split_typed_segments("naive - \u{65e5}\u{672c}\u{8a9e} \u{1f642}"),
+      vec![text("naive - \u{65e5}\u{672c}\u{8a9e} \u{1f642}")]
+    );
+  }
+}

--- a/app/src-tauri/src/utils.rs
+++ b/app/src-tauri/src/utils.rs
@@ -85,7 +85,24 @@ pub fn play_wav_blocking_windows(_app: &tauri::AppHandle, _wav_path: &str) -> Re
 /// ignored: if input simulation is unavailable the calling flow would silently
 /// read a stale clipboard and act on the wrong text.
 pub fn send_ctrl_key(ch: char) -> Result<(), String> {
-  send_chord(enigo::Key::Unicode(ch), false, &format!("Ctrl+{ch}"))
+  send_chord(enigo::Key::Unicode(ch), true, false, &format!("Ctrl+{ch}"))
+}
+
+/// Synthesize `Ctrl`+`Shift`+`ch`.
+///
+/// The paste combo for terminals and consoles, where plain Ctrl+V is either a
+/// control character or bound to something else entirely.
+pub fn send_ctrl_shift_key(ch: char) -> Result<(), String> {
+  send_chord(enigo::Key::Unicode(ch), true, true, &format!("Ctrl+Shift+{ch}"))
+}
+
+/// Synthesize `Shift`+`Insert`.
+///
+/// The X11-era paste combo, still honoured by Windows consoles and most
+/// terminal emulators, and the one application that ignores both other combos
+/// usually answers to this.
+pub fn send_shift_insert() -> Result<(), String> {
+  send_chord(enigo::Key::Insert, false, true, "Shift+Insert")
 }
 
 /// Send Ctrl+Shift+Home, extending the selection from the caret back to the
@@ -95,23 +112,28 @@ pub fn send_ctrl_key(ch: char) -> Result<(), String> {
 /// box or comment field it grabs exactly the text the user just typed, without
 /// swallowing the conversation history that Ctrl+A would also select.
 pub fn send_ctrl_shift_home() -> Result<(), String> {
-  send_chord(enigo::Key::Home, true, "Ctrl+Shift+Home")
+  send_chord(enigo::Key::Home, true, true, "Ctrl+Shift+Home")
 }
 
-/// Click `key` while Control - and optionally Shift - are held.
+/// Click `key` while Control and/or Shift are held.
 ///
-/// The modifiers are always released, even when the key itself fails, so a
-/// failed simulation never leaves the user with a stuck Ctrl or Shift.
-fn send_chord(key: enigo::Key, shift: bool, label: &str) -> Result<(), String> {
+/// Every modifier that was pressed is released, even when the key itself
+/// fails, so a failed simulation never leaves the user with a stuck Ctrl or
+/// Shift.
+fn send_chord(key: enigo::Key, ctrl: bool, shift: bool, label: &str) -> Result<(), String> {
   use enigo::{Direction, Enigo, Key, Keyboard, Settings};
   let mut enigo = Enigo::new(&Settings::default())
     .map_err(|e| format!("input simulation unavailable: {e}"))?;
-  enigo
-    .key(Key::Control, Direction::Press)
-    .map_err(|e| format!("ctrl press failed: {e}"))?;
+  if ctrl {
+    enigo
+      .key(Key::Control, Direction::Press)
+      .map_err(|e| format!("ctrl press failed: {e}"))?;
+  }
   if shift {
     if let Err(e) = enigo.key(Key::Shift, Direction::Press) {
-      let _ = enigo.key(Key::Control, Direction::Release);
+      if ctrl {
+        let _ = enigo.key(Key::Control, Direction::Release);
+      }
       return Err(format!("shift press failed: {e}"));
     }
   }
@@ -125,9 +147,13 @@ fn send_chord(key: enigo::Key, shift: bool, label: &str) -> Result<(), String> {
   } else {
     Ok(())
   };
-  let ctrl_release = enigo
-    .key(Key::Control, Direction::Release)
-    .map_err(|e| format!("ctrl release failed: {e}"));
+  let ctrl_release = if ctrl {
+    enigo
+      .key(Key::Control, Direction::Release)
+      .map_err(|e| format!("ctrl release failed: {e}"))
+  } else {
+    Ok(())
+  };
   click.and(shift_release).and(ctrl_release)
 }
 

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -755,30 +755,20 @@ async function stopSTTAndTranscribe(): Promise<void> {
       console.error('[stt] transcribe failed:', msg, err)
       return
     }
-    // Only paste non-empty transcription into the previously focused application.
-    // In clipboard mode the result goes on the clipboard first as a safety net:
-    // insert_text_into_focused_app does its own clipboard save/restore cycle, so
-    // the text survives either way. Keystroke mode deliberately skips that net -
-    // its whole point is to leave the clipboard alone - which means a failed
-    // insertion there loses the transcript.
+    // Only insert a non-empty transcription into the previously focused
+    // application. This used to copy the transcript to the clipboard first as a
+    // safety net, which quietly overrode the user's clipboard preference on
+    // every transcription. The `clipboard_handling` setting now decides what the
+    // clipboard ends up holding, so the net only fires when the insertion
+    // actually failed - otherwise a lost transcript would be the only trace.
     if (text && text.trim().length > 0) {
-      let insertMode = 'clipboard'
-      try {
-        const cfg = await invoke<any>('get_settings')
-        if (String(cfg?.insert_mode || '') === 'keystrokes') insertMode = 'keystrokes'
-      } catch {}
-      if (insertMode === 'clipboard') {
-        try { await invoke('copy_text_to_clipboard', { text }) } catch {}
-      }
-      // Try auto-insert into the previously focused app
       try {
         await invoke('refocus_previous_app')
         await new Promise((r) => setTimeout(r, 80))
         await invoke('insert_text_into_focused_app', { text, safe_mode: false })
       } catch (err) {
-        // In clipboard mode the text is already on the clipboard from above; in
-        // keystroke mode nothing caught it, so at least say so.
-        if (insertMode === 'keystrokes') console.error('[stt] insert failed, transcript not recovered', err)
+        console.error('[stt] insert failed, falling back to the clipboard', err)
+        try { await invoke('copy_text_to_clipboard', { text }) } catch {}
       }
     }
   } finally {

--- a/app/src/QuickActions.vue
+++ b/app/src/QuickActions.vue
@@ -756,19 +756,29 @@ async function stopSTTAndTranscribe(): Promise<void> {
       return
     }
     // Only paste non-empty transcription into the previously focused application.
-    // Put result in clipboard first as safety net, then try auto-paste.
-    // insert_text_into_focused_app does its own clipboard save/restore cycle,
-    // so the text survives either way.
+    // In clipboard mode the result goes on the clipboard first as a safety net:
+    // insert_text_into_focused_app does its own clipboard save/restore cycle, so
+    // the text survives either way. Keystroke mode deliberately skips that net -
+    // its whole point is to leave the clipboard alone - which means a failed
+    // insertion there loses the transcript.
     if (text && text.trim().length > 0) {
-      // Safety: always put text on clipboard first
-      try { await invoke('copy_text_to_clipboard', { text }) } catch {}
-      // Try auto-paste into the previously focused app
+      let insertMode = 'clipboard'
+      try {
+        const cfg = await invoke<any>('get_settings')
+        if (String(cfg?.insert_mode || '') === 'keystrokes') insertMode = 'keystrokes'
+      } catch {}
+      if (insertMode === 'clipboard') {
+        try { await invoke('copy_text_to_clipboard', { text }) } catch {}
+      }
+      // Try auto-insert into the previously focused app
       try {
         await invoke('refocus_previous_app')
         await new Promise((r) => setTimeout(r, 80))
         await invoke('insert_text_into_focused_app', { text, safe_mode: false })
-      } catch {
-        // Auto-paste failed — text is already on clipboard from above
+      } catch (err) {
+        // In clipboard mode the text is already on the clipboard from above; in
+        // keystroke mode nothing caught it, so at least say so.
+        if (insertMode === 'keystrokes') console.error('[stt] insert failed, transcript not recovered', err)
       }
     }
   } finally {

--- a/app/src/components/settings/SettingsGeneral.vue
+++ b/app/src/components/settings/SettingsGeneral.vue
@@ -124,6 +124,32 @@ onMounted(async () => {
   </CollapsibleCard>
 
   <CollapsibleCard
+    id="settings.general.insertion"
+    title="Text insertion"
+    desc="How results are put back into the application you were working in."
+  >
+    <div class="field">
+      <label class="field-label">Insert results using</label>
+      <select v-model="props.settings.insert_mode" class="input w-md">
+        <option value="clipboard">Clipboard + Ctrl + V (default)</option>
+        <option value="keystrokes">Simulated keystrokes (leaves the clipboard alone)</option>
+      </select>
+      <p class="field-hint">
+        Applies to every result that goes back into the focused app: quick prompts, the Quick Actions popup,
+        transcriptions and Assistant Mode.
+      </p>
+    </div>
+
+    <p class="field-hint">
+      <em>Clipboard</em> briefly replaces what you had copied, pastes, then puts it back - exact and instant at any
+      length, but it shows up in clipboard-history tools and cannot carry a copied image through untouched.
+      <em>Simulated keystrokes</em> never open the clipboard, at two costs: long results type visibly rather than
+      appearing at once, and each line break is a real <em>Enter</em> press, which <strong>sends the message</strong>
+      in Teams, Slack and most web chat boxes. Prefer it for editors, terminals and single-line fields.
+    </p>
+  </CollapsibleCard>
+
+  <CollapsibleCard
     id="settings.general.provider"
     title="AI Provider"
     desc="Credentials and the model used for chat and quick prompts."

--- a/app/src/components/settings/SettingsGeneral.vue
+++ b/app/src/components/settings/SettingsGeneral.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 import HotkeyPicker from './HotkeyPicker.vue'
 import CollapsibleCard from '../ui/CollapsibleCard.vue'
+import { MAX_PASTE_DELAY_MS } from '../../composables/useSettings'
 
 const props = defineProps<{
   settings: any
@@ -34,6 +35,12 @@ function duplicateHotkey(): string {
 }
 
 const hotkeysCollide = computed(() => !!duplicateHotkey())
+
+// Only the three combo-sending modes go through the clipboard, so only they
+// have a paste delay to tune or a clipboard to restore.
+const usesClipboardPaste = computed(
+  () => ['ctrl_v', 'ctrl_shift_v', 'shift_insert'].includes(String(props.settings.insert_mode))
+)
 
 function shorten(text: string): string {
   const t = (text || '').replace(/\s+/g, ' ').trim()
@@ -131,8 +138,11 @@ onMounted(async () => {
     <div class="field">
       <label class="field-label">Insert results using</label>
       <select v-model="props.settings.insert_mode" class="input w-md">
-        <option value="clipboard">Clipboard + Ctrl + V (default)</option>
-        <option value="keystrokes">Simulated keystrokes (leaves the clipboard alone)</option>
+        <option value="ctrl_v">Ctrl + V (default)</option>
+        <option value="ctrl_shift_v">Ctrl + Shift + V - for terminals</option>
+        <option value="shift_insert">Shift + Insert - for terminals</option>
+        <option value="keystrokes">Simulated keystrokes - never touches the clipboard</option>
+        <option value="none">Do not insert</option>
       </select>
       <p class="field-hint">
         Applies to every result that goes back into the focused app: quick prompts, the Quick Actions popup,
@@ -140,12 +150,43 @@ onMounted(async () => {
       </p>
     </div>
 
+    <div class="field">
+      <label class="field-label">Afterwards, the clipboard holds</label>
+      <select v-model="props.settings.clipboard_handling" class="input w-md">
+        <option value="dont_modify">What it held before (default)</option>
+        <option value="copy_to_clipboard">The inserted result</option>
+      </select>
+      <p class="field-hint">
+        Pair <em>The inserted result</em> with <em>Do not insert</em> above when you want the result put on your
+        clipboard and nothing else - nothing is typed or pasted anywhere.
+      </p>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Paste delay</label>
+      <input
+        type="number"
+        class="input w-sm"
+        v-model.number="props.settings.paste_delay_ms"
+        min="0"
+        :max="MAX_PASTE_DELAY_MS"
+        step="10"
+        :disabled="!usesClipboardPaste"
+      />
+      <p class="field-hint">
+        Milliseconds to wait after pasting before the clipboard is put back. Raise it if an application sometimes
+        pastes your <em>previous</em> clipboard contents instead of the result - it read the clipboard more slowly
+        than we restored it. Only applies to the three combo methods.
+      </p>
+    </div>
+
     <p class="field-hint">
-      <em>Clipboard</em> briefly replaces what you had copied, pastes, then puts it back - exact and instant at any
-      length, but it shows up in clipboard-history tools and cannot carry a copied image through untouched.
+      The three combo methods briefly replace what you had copied, paste, then put it back - exact and instant at any
+      length, but they show up in clipboard-history tools and cannot carry a copied image through untouched. Reach for
+      <em>Ctrl + Shift + V</em> or <em>Shift + Insert</em> when a terminal ignores plain Ctrl + V.
       <em>Simulated keystrokes</em> never open the clipboard, at two costs: long results type visibly rather than
       appearing at once, and each line break is a real <em>Enter</em> press, which <strong>sends the message</strong>
-      in Teams, Slack and most web chat boxes. Prefer it for editors, terminals and single-line fields.
+      in Teams, Slack and most web chat boxes.
     </p>
   </CollapsibleCard>
 

--- a/app/src/composables/useSettings.ts
+++ b/app/src/composables/useSettings.ts
@@ -10,11 +10,19 @@ export type UIStyle = 'sidebar-dark' | 'sidebar-light'
 export const SELECT_ALL_CAPTURE_MODES = ['none', 'ctrl_a', 'ctrl_shift_home'] as const
 export type SelectAllCaptureMode = (typeof SELECT_ALL_CAPTURE_MODES)[number]
 
-/// How a result is put back into the focused application: through the
-/// clipboard (set it, send Ctrl+V, restore the old contents) or as simulated
-/// keystrokes that never touch the clipboard.
-export const INSERT_MODES = ['clipboard', 'keystrokes'] as const
+/// How a result is put back into the focused application. The first three go
+/// through the clipboard and differ only in the combo they send; `keystrokes`
+/// types the text and never touches the clipboard; `none` inserts nothing.
+export const INSERT_MODES = ['ctrl_v', 'ctrl_shift_v', 'shift_insert', 'keystrokes', 'none'] as const
 export type InsertMode = (typeof INSERT_MODES)[number]
+
+/// What the clipboard holds once an insertion has finished: whatever was there
+/// before, or the text that was just inserted.
+export const CLIPBOARD_HANDLINGS = ['dont_modify', 'copy_to_clipboard'] as const
+export type ClipboardHandling = (typeof CLIPBOARD_HANDLINGS)[number]
+
+/// Ceiling for `paste_delay_ms`, matching MAX_PASTE_DELAY_MS in config.rs.
+export const MAX_PASTE_DELAY_MS = 2000
 
 // Module-singleton state to ensure all components share the same settings instance
 const DEFAULT_SYSTEM_PROMPT = (
@@ -49,9 +57,11 @@ const settings = reactive({
   pause_media_on_assistant: false as boolean,
   select_all_quick_prompt: 1 as number,
   select_all_capture_mode: 'ctrl_shift_home' as SelectAllCaptureMode,
-  // How results reach the focused app. Clipboard is the default because
-  // keystroke mode turns every newline into a real Return press.
-  insert_mode: 'clipboard' as InsertMode,
+  // How results reach the focused app. Ctrl+V is the default because keystroke
+  // mode turns every newline into a real Return press.
+  insert_mode: 'ctrl_v' as InsertMode,
+  clipboard_handling: 'dont_modify' as ClipboardHandling,
+  paste_delay_ms: 120 as number,
   // Floating status pill for background operations (quick prompts, TTS, STT)
   show_busy_indicator: true as boolean,
   mcp_servers: [] as Array<any>,
@@ -106,8 +116,19 @@ export function useSettings() {
         settings.select_all_capture_mode = SELECT_ALL_CAPTURE_MODES.includes(mode) ? mode : 'ctrl_shift_home'
       }
       {
-        const mode = (v as any).insert_mode
-        settings.insert_mode = INSERT_MODES.includes(mode) ? mode : 'clipboard'
+        // "clipboard" was the value of the two-way toggle this setting replaced.
+        const mode = (v as any).insert_mode === 'clipboard' ? 'ctrl_v' : (v as any).insert_mode
+        settings.insert_mode = INSERT_MODES.includes(mode) ? mode : 'ctrl_v'
+      }
+      {
+        const mode = (v as any).clipboard_handling
+        settings.clipboard_handling = CLIPBOARD_HANDLINGS.includes(mode) ? mode : 'dont_modify'
+      }
+      {
+        const ms = Number((v as any).paste_delay_ms)
+        settings.paste_delay_ms = Number.isFinite(ms)
+          ? Math.min(MAX_PASTE_DELAY_MS, Math.max(0, Math.trunc(ms)))
+          : 120
       }
       {
         const idx = Number((v as any).select_all_quick_prompt)

--- a/app/src/composables/useSettings.ts
+++ b/app/src/composables/useSettings.ts
@@ -10,6 +10,12 @@ export type UIStyle = 'sidebar-dark' | 'sidebar-light'
 export const SELECT_ALL_CAPTURE_MODES = ['none', 'ctrl_a', 'ctrl_shift_home'] as const
 export type SelectAllCaptureMode = (typeof SELECT_ALL_CAPTURE_MODES)[number]
 
+/// How a result is put back into the focused application: through the
+/// clipboard (set it, send Ctrl+V, restore the old contents) or as simulated
+/// keystrokes that never touch the clipboard.
+export const INSERT_MODES = ['clipboard', 'keystrokes'] as const
+export type InsertMode = (typeof INSERT_MODES)[number]
+
 // Module-singleton state to ensure all components share the same settings instance
 const DEFAULT_SYSTEM_PROMPT = (
   'For every user prompt, follow these steps internally before responding:\n' +
@@ -43,6 +49,9 @@ const settings = reactive({
   pause_media_on_assistant: false as boolean,
   select_all_quick_prompt: 1 as number,
   select_all_capture_mode: 'ctrl_shift_home' as SelectAllCaptureMode,
+  // How results reach the focused app. Clipboard is the default because
+  // keystroke mode turns every newline into a real Return press.
+  insert_mode: 'clipboard' as InsertMode,
   // Floating status pill for background operations (quick prompts, TTS, STT)
   show_busy_indicator: true as boolean,
   mcp_servers: [] as Array<any>,
@@ -95,6 +104,10 @@ export function useSettings() {
       {
         const mode = (v as any).select_all_capture_mode
         settings.select_all_capture_mode = SELECT_ALL_CAPTURE_MODES.includes(mode) ? mode : 'ctrl_shift_home'
+      }
+      {
+        const mode = (v as any).insert_mode
+        settings.insert_mode = INSERT_MODES.includes(mode) ? mode : 'clipboard'
       }
       {
         const idx = Number((v as any).select_all_quick_prompt)


### PR DESCRIPTION
Text insertion into the focused app was always clipboard + Ctrl+V, with the previous clipboard saved and restored around it. This makes the route configurable, adopting the shape Handy uses.

## Settings -> General -> Text insertion

**Insert results using**
- `ctrl_v` (default, current behaviour unchanged)
- `ctrl_shift_v` and `shift_insert` - the combos terminals and consoles answer to
- `keystrokes` - types the result, never opens the clipboard
- `none` - inserts nothing

**Afterwards, the clipboard holds** - what it held before (default), or the inserted result. Paired with `none` this gives copy-without-pasting.

**Paste delay** - the wait before the clipboard is restored, previously hardcoded at 120ms. Raise it when an application pastes the *previous* clipboard contents because it read the clipboard more slowly than we restored it.

Applies to every path that puts text back into the focused app: quick prompts, the select-all hotkey, the Quick Actions popup, transcriptions and Assistant Mode.

## Notes

- Keystroke mode lifts newlines and tabs out of the text and sends real Return and Tab presses, so no stray control characters reach the target. A real Return **sends the message** in Teams, Slack and most web chat boxes, which is why clipboard stays the default and the settings text says so outright.
- `send_chord` now takes Ctrl and Shift independently and releases only what it pressed, since Shift+Insert has no Ctrl. Selection capture and the select-all hotkey share this helper.
- Behaviour change worth noting: the STT flow used to copy every transcript to the clipboard *before* inserting as a safety net, which silently overrode the clipboard preference on every transcription. It now fires only when the insertion actually failed.

## Verification

- `cargo test --features local-stt --lib` - 29 passed, 0 failed, no warnings (15 new tests covering the newline/tab splitting and the settings normalizers)
- `npm run build` - `vue-tsc` clean

Not verified: runtime behaviour in real applications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)