### PR TITLE
fix(app): warn when the insertion settings would discard the result

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "AiDesktopCompanion",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "AiDesktopCompanion",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@dqbd/tiktoken": "^1.0.22",
         "@tauri-apps/api": "^2.11.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AiDesktopCompanion",
   "private": true,
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AiDesktopCompanion"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "arboard",
  "base64 0.23.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "AiDesktopCompanion"
-version = "0.1.20"
+version = "0.1.21"
 description = "AiDesktopCompanion"
 authors = ["exlasch"]
 license = ""

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// AiDesktopCompanion v0.1.20 build34
+// AiDesktopCompanion v0.1.21 build35
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "AiDesktopCompanion",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "identifier": "de.schick-nest.aidesktopcompanion",
   "build": {
     "frontendDist": "../dist",

--- a/app/src/components/settings/SettingsGeneral.vue
+++ b/app/src/components/settings/SettingsGeneral.vue
@@ -42,6 +42,15 @@ const usesClipboardPaste = computed(
   () => ['ctrl_v', 'ctrl_shift_v', 'shift_insert'].includes(String(props.settings.insert_mode))
 )
 
+// Inserting nothing while also restoring the clipboard leaves the result with
+// nowhere to go: the request still runs and is still billed, and the answer is
+// dropped on the floor. The one defensible reason to want it is reading results
+// in the popup preview, so this warns rather than forbidding the combination.
+const insertionDiscardsResult = computed(
+  () => String(props.settings.insert_mode) === 'none'
+    && String(props.settings.clipboard_handling) === 'dont_modify'
+)
+
 function shorten(text: string): string {
   const t = (text || '').replace(/\s+/g, ' ').trim()
   if (!t) return '(empty)'
@@ -147,6 +156,12 @@ onMounted(async () => {
       <p class="field-hint">
         Applies to every result that goes back into the focused app: quick prompts, the Quick Actions popup,
         transcriptions and Assistant Mode.
+      </p>
+      <p v-if="insertionDiscardsResult" class="field-hint error">
+        <strong>The result is being thrown away.</strong> Nothing is inserted, and the clipboard is restored to what
+        it held before, so the answer goes nowhere - the request still runs and is still billed. Set
+        <em>Afterwards, the clipboard holds</em> to <em>The inserted result</em> to get copy-without-pasting. Ignore
+        this if you read results in the Quick Actions popup preview instead.
       </p>
     </div>
 


### PR DESCRIPTION
Two commits: the warning fix, and the 0.1.21 release bump.

## The fix

Setting **Insert results using** to *Do not insert* without also changing **Afterwards, the clipboard holds** leaves the result with nowhere to go. The request runs, is billed, and the answer is dropped silently. Found in testing.

The two settings are orthogonal by design, as they are in Handy, and the hint explaining that they pair up sat under the *clipboard* dropdown - the one a user reaching for "do not insert" never opens.

This warns at the point of the choice instead. The combination is not forbidden, because it is defensible when reading results in the Quick Actions popup preview, so the warning names that exception rather than blocking the choice.

## Release 0.1.21

Standard bump across the same six files as `chore(release): 0.1.20`.

## Verification

- `npm run build` - `vue-tsc` clean
- Version bump diff is identical in shape to the previous release commit: 6 files, 7 insertions, 7 deletions

Note: `build-windows.yml` has been failing on every push to main since `4df7261 fix(tauri): stay on the CUDA 12 ONNX Runtime` (2026-08-21), unrelated to this PR. Tag `v0.1.20` and a failing `build-windows` run were the same commit `d6d65ac`, and that commit released successfully with both MSI and NSIS artifacts, so the failure is environmental in that workflow rather than a broken build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)