### PR TITLE
feat(assistant): record call history with duration, cost and transcript

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -24,6 +24,8 @@ dependencies = [
  "parakeet-rs",
  "reqwest",
  "rmcp",
+ "rusqlite",
+ "rusqlite_migration",
  "screenshots",
  "serde",
  "serde_json",
@@ -1249,7 +1251,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -1470,6 +1472,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1554,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -2064,9 +2084,27 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -2839,6 +2877,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4480,6 +4529,30 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec 1.15.2",
+]
+
+[[package]]
+name = "rusqlite_migration"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc9767ae49274bafd3e55be9d30405a033b7a59548327d87fd4971fbb58e264"
+dependencies = [
+ "log",
+ "rusqlite",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -78,6 +78,13 @@ http-body-util = "0.1"
 bytes = "1"
 uuid = { version = "1.0", features = ["v4"] }
 tokio-stream = "0.1"
+# Call history. `bundled` compiles SQLite from source rather than looking for a
+# system library, which Windows does not ship - it costs a one-off build of the
+# amalgamation and removes the runtime dependency entirely.
+rusqlite = { version = "0.37", features = ["bundled"] }
+# Schema versioning via SQLite's `user_version` pragma, so migrations are a
+# static list in the source instead of files that have to ship alongside it.
+rusqlite_migration = "2.3"
 whisper-rs = { version = "0.16", optional = true }
 # Parakeet V3 only; the V2 backend and its git fork are gone.
 #

--- a/app/src-tauri/src/call_history.rs
+++ b/app/src-tauri/src/call_history.rs
@@ -1,0 +1,641 @@
+//! Persistent record of Assistant Mode voice calls.
+//!
+//! A realtime call is the most expensive thing this app does - it is billed per
+//! audio token, roughly one per 100ms heard and one per 50ms spoken - and until
+//! now every one of them vanished the moment the panel was closed. What it
+//! cost, what was said and how long it ran were visible while the session was
+//! on screen and then gone.
+//!
+//! Kept in SQLite rather than the JSON files the rest of the app uses. Calls
+//! accumulate one row at a time and are read back newest-first in pages, which
+//! is exactly what a rewrite-the-whole-file store is bad at; and the running
+//! total spend is a `SUM()` rather than a full parse.
+//!
+//! The database lives beside `settings.json` in `%APPDATA%\AiDesktopCompanion`,
+//! as `calls.db`. Transcripts are stored as plain text: anyone who can read that
+//! directory can read them, which is the same bargain `settings.json` already
+//! makes with the API key.
+
+use once_cell::sync::OnceCell;
+use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite_migration::{Migrations, M};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Schema history. Append only - `rusqlite_migration` tracks how far a database
+/// has been brought forward in SQLite's `user_version`, so editing an existing
+/// entry silently skips the change on every machine that already ran it.
+static MIGRATIONS: &[M] = &[M::up(
+  "CREATE TABLE IF NOT EXISTS calls (
+     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+     started_at      INTEGER NOT NULL,
+     duration_ms     INTEGER NOT NULL,
+     model           TEXT    NOT NULL,
+     voice           TEXT    NOT NULL,
+     saved           INTEGER NOT NULL DEFAULT 0,
+     title           TEXT    NOT NULL,
+     transcript      TEXT    NOT NULL,
+     turns           INTEGER NOT NULL DEFAULT 0,
+     responses       INTEGER NOT NULL DEFAULT 0,
+     audio_in        INTEGER NOT NULL DEFAULT 0,
+     audio_in_cached INTEGER NOT NULL DEFAULT 0,
+     audio_out       INTEGER NOT NULL DEFAULT 0,
+     text_in         INTEGER NOT NULL DEFAULT 0,
+     text_in_cached  INTEGER NOT NULL DEFAULT 0,
+     text_out        INTEGER NOT NULL DEFAULT 0,
+     cost_usd        REAL,
+     tools_enabled   INTEGER NOT NULL DEFAULT 0,
+     supervisor      TEXT
+   );
+   CREATE INDEX IF NOT EXISTS idx_calls_started_at ON calls (started_at DESC);",
+)];
+
+/// One recorded call.
+///
+/// Field names are the wire format in both directions, so the frontend sends
+/// and receives snake_case. Tauri rewrites *command arguments* to camelCase but
+/// leaves the insides of a serialized struct alone.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CallEntry {
+  /// Assigned by SQLite. Ignored on the way in.
+  #[serde(default)]
+  pub id: i64,
+  /// Unix seconds the call connected.
+  pub started_at: i64,
+  pub duration_ms: i64,
+  pub model: String,
+  pub voice: String,
+  /// Pinned by the user. Pinned calls survive every retention sweep.
+  #[serde(default)]
+  pub saved: bool,
+  /// First thing the user said, trimmed to a line. The list has to show
+  /// something recognisable without loading every transcript.
+  pub title: String,
+  /// The conversation as a JSON array of `{ "role": ..., "content": ... }`.
+  /// Stored as text rather than a table: it is only ever read back whole.
+  pub transcript: String,
+  pub turns: i64,
+  pub responses: i64,
+  pub audio_in: i64,
+  pub audio_in_cached: i64,
+  pub audio_out: i64,
+  pub text_in: i64,
+  pub text_in_cached: i64,
+  pub text_out: i64,
+  /// `None` when the model had no known rates, which is deliberately different
+  /// from `Some(0.0)` - one means "not priced here", the other "free".
+  pub cost_usd: Option<f64>,
+  #[serde(default)]
+  pub tools_enabled: bool,
+  /// `"always"`, `"needed"`, or `None` when no supervisor was used.
+  pub supervisor: Option<String>,
+}
+
+/// A page of calls, newest first.
+#[derive(Clone, Debug, Serialize)]
+pub struct CallPage {
+  pub entries: Vec<CallEntry>,
+  /// Whether another page exists after this one.
+  pub has_more: bool,
+}
+
+/// Lifetime totals, for the "what has this cost me" line.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CallStats {
+  pub calls: i64,
+  pub duration_ms: i64,
+  /// Sum over the calls that had known rates. Calls priced as `None` are
+  /// counted in `unpriced` instead of being quietly folded in as zero.
+  pub cost_usd: f64,
+  pub unpriced: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+/// How long unpinned calls are kept.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Retention {
+  /// Delete nothing.
+  KeepAll,
+  /// Delete anything older than this many days.
+  Days(i64),
+  /// Keep only this many, newest first.
+  Last(usize),
+}
+
+/// Normalize a persisted retention value, defaulting to `"days_30"`.
+///
+/// A month is long enough for "what did that cost last week" to still be
+/// answerable, and short enough that a year of recorded conversation does not
+/// pile up on disk because nobody ever looked at the setting.
+pub fn normalize_retention(value: &str) -> &'static str {
+  match value.trim() {
+    "keep_all" => "keep_all",
+    "days_7" => "days_7",
+    "months_3" => "months_3",
+    "last_50" => "last_50",
+    _ => "days_30",
+  }
+}
+
+pub fn parse_retention(value: &str) -> Retention {
+  match normalize_retention(value) {
+    "keep_all" => Retention::KeepAll,
+    "days_7" => Retention::Days(7),
+    "months_3" => Retention::Days(90),
+    "last_50" => Retention::Last(50),
+    _ => Retention::Days(30),
+  }
+}
+
+/// Whether calls are recorded at all, and for how long.
+///
+/// Both live inside the `assistant_realtime` blob in `settings.json`, which is
+/// persisted wholesale - so neither needs its own entry in the `save_settings`
+/// allowlist, and both are written by the same panel that reads them.
+fn settings_blob() -> serde_json::Value {
+  crate::config::load_settings_json()
+    .get("assistant_realtime")
+    .cloned()
+    .unwrap_or(serde_json::Value::Null)
+}
+
+pub fn recording_enabled() -> bool {
+  settings_blob()
+    .get("history_enabled")
+    .and_then(|x| x.as_bool())
+    .unwrap_or(true)
+}
+
+pub fn retention_from_settings() -> Retention {
+  let raw = settings_blob()
+    .get("history_retention")
+    .and_then(|x| x.as_str())
+    .unwrap_or("")
+    .to_string();
+  parse_retention(&raw)
+}
+
+// ---------------------------------------------------------------------------
+// Connection
+// ---------------------------------------------------------------------------
+
+fn db_file() -> Result<PathBuf, String> {
+  let settings = crate::config::settings_config_path()
+    .ok_or_else(|| "Unsupported platform for the config path".to_string())?;
+  let dir = settings
+    .parent()
+    .ok_or_else(|| "The config path has no parent directory".to_string())?;
+  std::fs::create_dir_all(dir).map_err(|e| format!("Could not create {}: {e}", dir.display()))?;
+  Ok(dir.join("calls.db"))
+}
+
+/// Resolved once. Migrations run on the first open of the process and not
+/// again, so the per-command opens below are just `Connection::open`.
+static READY: OnceCell<Result<PathBuf, String>> = OnceCell::new();
+
+fn open() -> Result<Connection, String> {
+  let path = READY
+    .get_or_init(|| {
+      let path = db_file()?;
+      let mut conn =
+        Connection::open(&path).map_err(|e| format!("Could not open {}: {e}", path.display()))?;
+      migrate(&mut conn)?;
+      Ok(path)
+    })
+    .clone()?;
+  Connection::open(&path).map_err(|e| format!("Could not open the call history database: {e}"))
+}
+
+fn migrate(conn: &mut Connection) -> Result<(), String> {
+  Migrations::new(MIGRATIONS.to_vec())
+    .to_latest(conn)
+    .map_err(|e| format!("Call history migration failed: {e}"))?;
+  Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+//
+// Each takes a `&Connection` rather than opening its own, so all of the
+// behaviour below is reachable from a test against an in-memory database.
+// ---------------------------------------------------------------------------
+
+fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<CallEntry> {
+  Ok(CallEntry {
+    id: row.get("id")?,
+    started_at: row.get("started_at")?,
+    duration_ms: row.get("duration_ms")?,
+    model: row.get("model")?,
+    voice: row.get("voice")?,
+    saved: row.get::<_, i64>("saved")? != 0,
+    title: row.get("title")?,
+    transcript: row.get("transcript")?,
+    turns: row.get("turns")?,
+    responses: row.get("responses")?,
+    audio_in: row.get("audio_in")?,
+    audio_in_cached: row.get("audio_in_cached")?,
+    audio_out: row.get("audio_out")?,
+    text_in: row.get("text_in")?,
+    text_in_cached: row.get("text_in_cached")?,
+    text_out: row.get("text_out")?,
+    cost_usd: row.get("cost_usd")?,
+    tools_enabled: row.get::<_, i64>("tools_enabled")? != 0,
+    supervisor: row.get("supervisor")?,
+  })
+}
+
+const SELECT_COLUMNS: &str = "id, started_at, duration_ms, model, voice, saved, title, transcript, \
+   turns, responses, audio_in, audio_in_cached, audio_out, text_in, text_in_cached, text_out, \
+   cost_usd, tools_enabled, supervisor";
+
+pub fn insert(conn: &Connection, entry: &CallEntry) -> Result<i64, String> {
+  conn
+    .execute(
+      "INSERT INTO calls (
+         started_at, duration_ms, model, voice, saved, title, transcript, turns, responses,
+         audio_in, audio_in_cached, audio_out, text_in, text_in_cached, text_out,
+         cost_usd, tools_enabled, supervisor
+       ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+      params![
+        entry.started_at,
+        entry.duration_ms,
+        entry.model,
+        entry.voice,
+        entry.saved as i64,
+        entry.title,
+        entry.transcript,
+        entry.turns,
+        entry.responses,
+        entry.audio_in,
+        entry.audio_in_cached,
+        entry.audio_out,
+        entry.text_in,
+        entry.text_in_cached,
+        entry.text_out,
+        entry.cost_usd,
+        entry.tools_enabled as i64,
+        entry.supervisor,
+      ],
+    )
+    .map_err(|e| format!("Could not record the call: {e}"))?;
+  Ok(conn.last_insert_rowid())
+}
+
+/// Newest first, paged by id.
+///
+/// The cursor is an id rather than an offset. Ids only ever increase, so a page
+/// boundary stays put even if a call is deleted or recorded while the list is
+/// open - an offset would skip or repeat a row in exactly that case.
+pub fn list(conn: &Connection, cursor: Option<i64>, limit: usize) -> Result<CallPage, String> {
+  let limit = limit.clamp(1, 200);
+  // One extra row, purely to answer "is there more" without a second query.
+  let fetch = (limit + 1) as i64;
+
+  let sql = match cursor {
+    Some(_) => format!("SELECT {SELECT_COLUMNS} FROM calls WHERE id < ?1 ORDER BY id DESC LIMIT ?2"),
+    None => format!("SELECT {SELECT_COLUMNS} FROM calls ORDER BY id DESC LIMIT ?1"),
+  };
+  let mut stmt = conn
+    .prepare(&sql)
+    .map_err(|e| format!("Could not read the call history: {e}"))?;
+
+  let mapped = match cursor {
+    Some(id) => stmt.query_map(params![id, fetch], row_to_entry),
+    None => stmt.query_map(params![fetch], row_to_entry),
+  }
+  .map_err(|e| format!("Could not read the call history: {e}"))?;
+
+  let mut entries: Vec<CallEntry> = Vec::new();
+  for row in mapped {
+    entries.push(row.map_err(|e| format!("Could not read a call: {e}"))?);
+  }
+
+  let has_more = entries.len() > limit;
+  entries.truncate(limit);
+  Ok(CallPage { entries, has_more })
+}
+
+pub fn get(conn: &Connection, id: i64) -> Result<Option<CallEntry>, String> {
+  conn
+    .query_row(
+      &format!("SELECT {SELECT_COLUMNS} FROM calls WHERE id = ?1"),
+      params![id],
+      row_to_entry,
+    )
+    .optional()
+    .map_err(|e| format!("Could not read call {id}: {e}"))
+}
+
+pub fn set_saved(conn: &Connection, id: i64, saved: bool) -> Result<(), String> {
+  conn
+    .execute(
+      "UPDATE calls SET saved = ?1 WHERE id = ?2",
+      params![saved as i64, id],
+    )
+    .map_err(|e| format!("Could not pin call {id}: {e}"))?;
+  Ok(())
+}
+
+pub fn delete(conn: &Connection, id: i64) -> Result<(), String> {
+  conn
+    .execute("DELETE FROM calls WHERE id = ?1", params![id])
+    .map_err(|e| format!("Could not delete call {id}: {e}"))?;
+  Ok(())
+}
+
+/// Delete everything, or everything the user has not pinned.
+pub fn clear(conn: &Connection, keep_saved: bool) -> Result<usize, String> {
+  let sql = if keep_saved {
+    "DELETE FROM calls WHERE saved = 0"
+  } else {
+    "DELETE FROM calls"
+  };
+  conn
+    .execute(sql, [])
+    .map_err(|e| format!("Could not clear the call history: {e}"))
+}
+
+pub fn stats(conn: &Connection) -> Result<CallStats, String> {
+  conn
+    .query_row(
+      "SELECT COUNT(*),
+              COALESCE(SUM(duration_ms), 0),
+              COALESCE(SUM(cost_usd), 0),
+              COALESCE(SUM(cost_usd IS NULL), 0)
+       FROM calls",
+      [],
+      |row| {
+        Ok(CallStats {
+          calls: row.get(0)?,
+          duration_ms: row.get(1)?,
+          cost_usd: row.get(2)?,
+          unpriced: row.get(3)?,
+        })
+      },
+    )
+    .map_err(|e| format!("Could not total the call history: {e}"))
+}
+
+/// Apply the retention policy. Returns how many calls were removed.
+///
+/// Pinned calls are never touched, by either policy. That is the whole point of
+/// the pin: a call worth keeping should not also need the user to remember to
+/// change a global setting before the next sweep runs.
+pub fn cleanup(conn: &Connection, retention: Retention, now: i64) -> Result<usize, String> {
+  match retention {
+    Retention::KeepAll => Ok(0),
+    Retention::Days(days) => {
+      let cutoff = now - days * 24 * 60 * 60;
+      conn
+        .execute(
+          "DELETE FROM calls WHERE saved = 0 AND started_at < ?1",
+          params![cutoff],
+        )
+        .map_err(|e| format!("Could not apply the retention policy: {e}"))
+    }
+    Retention::Last(keep) => conn
+      .execute(
+        // Rank unpinned calls newest-first and drop everything past the limit.
+        // Pinned calls are excluded from the ranking as well as from the
+        // delete, so pinning one does not push an unpinned call out of the
+        // window it was already inside.
+        "DELETE FROM calls WHERE saved = 0 AND id NOT IN (
+           SELECT id FROM calls WHERE saved = 0 ORDER BY id DESC LIMIT ?1
+         )",
+        params![keep as i64],
+      )
+      .map_err(|e| format!("Could not apply the retention policy: {e}")),
+  }
+}
+
+fn now_secs() -> i64 {
+  chrono::Utc::now().timestamp()
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/// Record a finished call, then apply the retention policy.
+///
+/// Returns the new row id, or `None` when recording is switched off - the
+/// frontend does not have to check the setting before offering to save.
+#[tauri::command]
+pub fn call_history_save(entry: CallEntry) -> Result<Option<i64>, String> {
+  if !recording_enabled() {
+    return Ok(None);
+  }
+  let conn = open()?;
+  let id = insert(&conn, &entry)?;
+  // Sweeping here rather than only at startup keeps an app that is left running
+  // for weeks from holding months of calls it was supposed to have dropped.
+  let _ = cleanup(&conn, retention_from_settings(), now_secs());
+  Ok(Some(id))
+}
+
+#[tauri::command]
+pub fn call_history_list(cursor: Option<i64>, limit: Option<u32>) -> Result<CallPage, String> {
+  let conn = open()?;
+  list(&conn, cursor, limit.unwrap_or(25) as usize)
+}
+
+#[tauri::command]
+pub fn call_history_get(id: i64) -> Result<Option<CallEntry>, String> {
+  let conn = open()?;
+  get(&conn, id)
+}
+
+#[tauri::command]
+pub fn call_history_set_saved(id: i64, saved: bool) -> Result<(), String> {
+  let conn = open()?;
+  set_saved(&conn, id, saved)
+}
+
+#[tauri::command]
+pub fn call_history_delete(id: i64) -> Result<(), String> {
+  let conn = open()?;
+  delete(&conn, id)
+}
+
+#[tauri::command]
+pub fn call_history_clear(keep_saved: bool) -> Result<usize, String> {
+  let conn = open()?;
+  clear(&conn, keep_saved)
+}
+
+#[tauri::command]
+pub fn call_history_stats() -> Result<CallStats, String> {
+  let conn = open()?;
+  stats(&conn)
+}
+
+/// Run the retention sweep now. Called once at startup.
+#[tauri::command]
+pub fn call_history_cleanup() -> Result<usize, String> {
+  let conn = open()?;
+  cleanup(&conn, retention_from_settings(), now_secs())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn memory_db() -> Connection {
+    let mut conn = Connection::open_in_memory().expect("in-memory database");
+    migrate(&mut conn).expect("migrations apply");
+    conn
+  }
+
+  fn entry(started_at: i64, cost: Option<f64>) -> CallEntry {
+    CallEntry {
+      id: 0,
+      started_at,
+      duration_ms: 60_000,
+      model: "gpt-realtime-2.1-mini".into(),
+      voice: "alloy".into(),
+      saved: false,
+      title: "What is the build status".into(),
+      transcript: "[]".into(),
+      turns: 2,
+      responses: 1,
+      audio_in: 100,
+      audio_in_cached: 10,
+      audio_out: 200,
+      text_in: 5,
+      text_in_cached: 0,
+      text_out: 7,
+      cost_usd: cost,
+      tools_enabled: true,
+      supervisor: None,
+    }
+  }
+
+  #[test]
+  fn round_trips_a_call() {
+    let conn = memory_db();
+    let id = insert(&conn, &entry(1_000, Some(0.0421))).unwrap();
+    let back = get(&conn, id).unwrap().expect("the call is there");
+    assert_eq!(back.id, id);
+    assert_eq!(back.model, "gpt-realtime-2.1-mini");
+    assert_eq!(back.cost_usd, Some(0.0421));
+    assert!(back.tools_enabled);
+    assert!(!back.saved);
+  }
+
+  #[test]
+  fn an_unpriced_call_stays_unpriced() {
+    // Some(0.0) means the call was free; None means we do not know what it
+    // cost. Collapsing the second into the first would report real spend as
+    // zero, so the column has to survive the round trip as NULL.
+    let conn = memory_db();
+    let id = insert(&conn, &entry(1_000, None)).unwrap();
+    assert_eq!(get(&conn, id).unwrap().unwrap().cost_usd, None);
+  }
+
+  #[test]
+  fn lists_newest_first_and_pages_by_id() {
+    let conn = memory_db();
+    for i in 0..5 {
+      insert(&conn, &entry(1_000 + i, Some(0.01))).unwrap();
+    }
+    let first = list(&conn, None, 2).unwrap();
+    assert_eq!(first.entries.len(), 2);
+    assert!(first.has_more);
+    assert!(first.entries[0].id > first.entries[1].id);
+
+    let cursor = first.entries.last().unwrap().id;
+    let second = list(&conn, Some(cursor), 2).unwrap();
+    assert_eq!(second.entries.len(), 2);
+    assert!(second.entries.iter().all(|e| e.id < cursor));
+
+    let third = list(&conn, Some(second.entries.last().unwrap().id), 2).unwrap();
+    assert_eq!(third.entries.len(), 1);
+    assert!(!third.has_more);
+  }
+
+  #[test]
+  fn stats_separate_unpriced_calls_from_free_ones() {
+    let conn = memory_db();
+    insert(&conn, &entry(1_000, Some(0.25))).unwrap();
+    insert(&conn, &entry(2_000, Some(0.25))).unwrap();
+    insert(&conn, &entry(3_000, None)).unwrap();
+    let s = stats(&conn).unwrap();
+    assert_eq!(s.calls, 3);
+    assert_eq!(s.unpriced, 1);
+    assert!((s.cost_usd - 0.5).abs() < 1e-9);
+    assert_eq!(s.duration_ms, 180_000);
+  }
+
+  #[test]
+  fn retention_by_age_spares_pinned_calls() {
+    let conn = memory_db();
+    let now = 10_000_000_i64;
+    let old = now - 40 * 24 * 60 * 60;
+    let stale = insert(&conn, &entry(old, Some(0.01))).unwrap();
+    let pinned = insert(&conn, &entry(old, Some(0.01))).unwrap();
+    let recent = insert(&conn, &entry(now - 60, Some(0.01))).unwrap();
+    set_saved(&conn, pinned, true).unwrap();
+
+    assert_eq!(cleanup(&conn, Retention::Days(30), now).unwrap(), 1);
+    assert!(get(&conn, stale).unwrap().is_none());
+    assert!(get(&conn, pinned).unwrap().is_some());
+    assert!(get(&conn, recent).unwrap().is_some());
+  }
+
+  #[test]
+  fn retention_by_count_keeps_the_newest_unpinned() {
+    let conn = memory_db();
+    let mut ids = Vec::new();
+    for i in 0..5 {
+      ids.push(insert(&conn, &entry(1_000 + i, Some(0.01))).unwrap());
+    }
+    // Pin the oldest. It must survive, and must not consume one of the two
+    // slots the policy reserves for recent calls.
+    set_saved(&conn, ids[0], true).unwrap();
+
+    assert_eq!(cleanup(&conn, Retention::Last(2), 10_000).unwrap(), 2);
+    assert!(get(&conn, ids[0]).unwrap().is_some());
+    assert!(get(&conn, ids[1]).unwrap().is_none());
+    assert!(get(&conn, ids[2]).unwrap().is_none());
+    assert!(get(&conn, ids[3]).unwrap().is_some());
+    assert!(get(&conn, ids[4]).unwrap().is_some());
+  }
+
+  #[test]
+  fn keep_all_deletes_nothing() {
+    let conn = memory_db();
+    insert(&conn, &entry(1, Some(0.01))).unwrap();
+    assert_eq!(cleanup(&conn, Retention::KeepAll, 10_000_000).unwrap(), 0);
+    assert_eq!(stats(&conn).unwrap().calls, 1);
+  }
+
+  #[test]
+  fn clearing_can_spare_pinned_calls() {
+    let conn = memory_db();
+    let a = insert(&conn, &entry(1, Some(0.01))).unwrap();
+    let b = insert(&conn, &entry(2, Some(0.01))).unwrap();
+    set_saved(&conn, b, true).unwrap();
+
+    assert_eq!(clear(&conn, true).unwrap(), 1);
+    assert!(get(&conn, a).unwrap().is_none());
+    assert!(get(&conn, b).unwrap().is_some());
+
+    assert_eq!(clear(&conn, false).unwrap(), 1);
+    assert_eq!(stats(&conn).unwrap().calls, 0);
+  }
+
+  #[test]
+  fn retention_values_normalize_to_a_known_set() {
+    for v in ["keep_all", "days_7", "days_30", "months_3", "last_50"] {
+      assert_eq!(normalize_retention(v), v);
+    }
+    assert_eq!(normalize_retention("  days_7 \n"), "days_7");
+    assert_eq!(normalize_retention(""), "days_30");
+    assert_eq!(normalize_retention("forever"), "days_30");
+    assert_eq!(parse_retention("months_3"), Retention::Days(90));
+    assert_eq!(parse_retention("nonsense"), Retention::Days(30));
+  }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -86,6 +86,17 @@ pub fn run() {
       if let Some(win) = app.get_webview_window(busy::BUSY_WINDOW_LABEL) {
         busy::make_non_activating(&win);
       }
+      // Expire old calls once per launch, on a worker so a large sweep - or a
+      // first run that has to create and migrate the database - never delays
+      // the window appearing. A failure here is not worth blocking startup for:
+      // the sweep also runs after every call.
+      std::thread::spawn(|| {
+        match call_history::call_history_cleanup() {
+          Ok(0) => {}
+          Ok(n) => log::info!("call history: expired {n} calls"),
+          Err(e) => log::warn!("call history: retention sweep failed: {e}"),
+        }
+      });
       Ok(())
     })
     .invoke_handler(tauri::generate_handler![
@@ -168,7 +179,15 @@ pub fn run() {
       updater::check_for_update,
       updater::open_release_page,
       busy::busy_get_state,
-      busy::busy_hide
+      busy::busy_hide,
+      call_history::call_history_save,
+      call_history::call_history_list,
+      call_history::call_history_get,
+      call_history::call_history_set_saved,
+      call_history::call_history_delete,
+      call_history::call_history_clear,
+      call_history::call_history_stats,
+      call_history::call_history_cleanup
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
@@ -207,6 +226,7 @@ mod command_hook;
 mod busy;
 mod updater;
 mod assistant_pill;
+mod call_history;
 mod media;
 mod webview_health;
 

--- a/app/src/components/assistant/AssistantMode.vue
+++ b/app/src/components/assistant/AssistantMode.vue
@@ -4,7 +4,9 @@ import { invoke } from '@tauri-apps/api/core'
 import { useAssistantRealtime } from '../../composables/useAssistantRealtime'
 import { useSettings } from '../../composables/useSettings'
 import { useCallTones } from '../../composables/useCallTones'
+import { useCallHistory, titleFor, type CallDraft } from '../../composables/useCallHistory'
 import CollapsibleCard from '../ui/CollapsibleCard.vue'
+import CallHistory from './CallHistory.vue'
 import { listen } from '@tauri-apps/api/event'
 import type { UnlistenFn } from '@tauri-apps/api/event'
 import { HOTKEY_EVENT_PTT_DOWN, HOTKEY_EVENT_PTT_UP } from '../../hotkeys'
@@ -318,6 +320,11 @@ const session = reactive({
   // the connect happens from a global hotkey with the window usually hidden, so
   // sound is the only feedback that reaches the user.
   callTones: true,
+  // Record finished calls to calls.db. On by default: what a voice call cost is
+  // the thing people most want to look back at, and it is unrecoverable once
+  // the session is gone.
+  historyEnabled: true,
+  historyRetention: 'days_30',
 })
 
 /**
@@ -359,6 +366,74 @@ const { settings: appSettings, loadSettings } = useSettings()
 
 const tones = useCallTones()
 
+// Used only to write finished calls. The list itself is owned by the
+// CallHistory card, which loads and pages its own copy.
+const recorder = useCallHistory()
+const historyRef = ref<any>(null)
+
+/**
+ * Epoch milliseconds the current call connected, and whether it has been
+ * written yet.
+ *
+ * `onDisconnected` is not fired once per call: an ICE state change to
+ * `disconnected` or `failed` raises it, and the explicit hang-up that follows
+ * raises it again. Without the guard a single call would be recorded twice.
+ */
+let callStartedMs = 0
+let callRecorded = true
+
+/**
+ * Write the call that has just ended.
+ *
+ * Deliberately does nothing for a session that connected but produced neither
+ * speech nor a billable response - a mis-press that was hung up immediately is
+ * not a call worth keeping, and a list full of empty ten-second rows makes the
+ * real ones hard to find.
+ */
+async function recordCall() {
+  if (callRecorded || !callStartedMs) return
+  callRecorded = true
+  const startedMs = callStartedMs
+  callStartedMs = 0
+
+  const turns = transcript.value.map((t) => ({ role: t.role, content: t.content }))
+  const spoken = turns.filter((t) => t.role !== 'tool')
+  const totals: any = usage.value
+  const responses = totals?.responses ?? 0
+  if (!spoken.length && responses === 0) return
+
+  const draft: CallDraft = {
+    started_at: Math.floor(startedMs / 1000),
+    duration_ms: Math.max(0, Date.now() - startedMs),
+    model: session.model,
+    voice: session.voice,
+    title: titleFor(turns),
+    transcript: JSON.stringify(turns),
+    turns: spoken.length,
+    responses,
+    audio_in: totals?.audioIn ?? 0,
+    audio_in_cached: totals?.audioInCached ?? 0,
+    audio_out: totals?.audioOut ?? 0,
+    text_in: totals?.textIn ?? 0,
+    text_in_cached: totals?.textInCached ?? 0,
+    text_out: totals?.textOut ?? 0,
+    // null, not zero, when the model has no known rates: "we do not know" and
+    // "it was free" must not read the same in the history.
+    cost_usd: (realtime as any).usage?.estimatedUsd?.value ?? null,
+    tools_enabled: ui.enableTools,
+    supervisor: ui.useSupervisor ? session.supervisorMode : null,
+  }
+
+  const id = await recorder.save(draft)
+  if (recorder.error.value) {
+    props.notify?.(recorder.error.value, 'error')
+    recorder.error.value = null
+    return
+  }
+  // null means recording is switched off, which is not a failure.
+  if (id !== null) void historyRef.value?.reload?.()
+}
+
 const realtime = useAssistantRealtime({
   getEphemeralToken: async () => {
     try {
@@ -372,8 +447,10 @@ const realtime = useAssistantRealtime({
       throw new Error('Could not mint a realtime token: ' + msg)
     }
   },
-  onConnected: () => { ui.connected = true; ui.connecting = false; ui.error = null; statusText.value = 'Connected'; startElapsed(); syncPill('live'); tones.stopRingback(); if (session.callTones) tones.readyBeep() },
-  onDisconnected: () => { ui.connected = false; ui.connecting = false; statusText.value = 'Idle'; stopElapsed(); syncPill('hidden'); tones.stopRingback() },
+  // The clock the history records starts here rather than at `activate`, so a
+  // slow token mint or ICE negotiation is not billed to the call's duration.
+  onConnected: () => { ui.connected = true; ui.connecting = false; ui.error = null; statusText.value = 'Connected'; startElapsed(); syncPill('live'); tones.stopRingback(); if (session.callTones) tones.readyBeep(); callStartedMs = Date.now(); callRecorded = false },
+  onDisconnected: () => { ui.connected = false; ui.connecting = false; statusText.value = 'Idle'; stopElapsed(); syncPill('hidden'); tones.stopRingback(); void recordCall() },
   // Ringing on past a failed connect would be a phone that never stops, so the
   // tone is stopped here as well as on the two success paths.
   onError: (err: string) => { ui.error = err; props.notify?.(err, 'error'); ui.connecting = false; ui.connected = false; statusText.value = 'Error'; tones.stopRingback(); syncPill('hidden'); try { debugLines.value.push(`[error] ${err}`) } catch {} },
@@ -465,6 +542,12 @@ onMounted(async () => {
       if (typeof ar.auto_close_minutes === 'number' && ar.auto_close_minutes >= 0) session.autoCloseMinutes = ar.auto_close_minutes
       if (ar.mic_mode === 'open' || ar.mic_mode === 'ptt') session.micMode = ar.mic_mode
       if (typeof ar.call_tones === 'boolean') session.callTones = ar.call_tones
+      if (typeof ar.history_enabled === 'boolean') session.historyEnabled = ar.history_enabled
+      // Kept in step with `normalize_retention` in call_history.rs; anything
+      // else falls back to the same default Rust would pick.
+      if (['keep_all', 'days_7', 'days_30', 'months_3', 'last_50'].includes(ar.history_retention)) {
+        session.historyRetention = ar.history_retention
+      }
       if (typeof ar.show_debug === 'boolean') ui.showDebug = ar.show_debug
       // Without these the voice session came up with an empty tool list on every
       // app start, and the only symptom was the model saying it had no tools.
@@ -509,6 +592,11 @@ watch([session, () => ui.enableTools, () => ui.useSupervisor, () => ui.showDebug
           auto_close_minutes: session.autoCloseMinutes,
           mic_mode: session.micMode,
           call_tones: session.callTones,
+          // Read back in Rust by call_history.rs, which is why they live in
+          // this blob rather than in a key of their own: `assistant_realtime`
+          // is persisted wholesale and needs no allowlist entry.
+          history_enabled: session.historyEnabled,
+          history_retention: session.historyRetention,
           show_debug: ui.showDebug,
         }
       }
@@ -810,6 +898,13 @@ onBeforeUnmount(() => {
       </button>
     </div>
   </CollapsibleCard>
+
+  <CallHistory
+    ref="historyRef"
+    :notify="props.notify"
+    v-model:recording="session.historyEnabled"
+    v-model:retention="session.historyRetention"
+  />
 
   <CollapsibleCard
     id="assistant.debug"

--- a/app/src/components/assistant/CallHistory.vue
+++ b/app/src/components/assistant/CallHistory.vue
@@ -1,0 +1,453 @@
+<script setup lang="ts">
+/**
+ * Past voice calls: when, how long, what it cost, and what was said.
+ *
+ * A realtime call is billed per audio token, so the only honest answer to "what
+ * am I spending on this" is a record of the calls themselves. The transcript
+ * comes along because it is already in memory when the call ends and is the
+ * thing that makes a row recognisable a week later.
+ *
+ * Rows are collapsed by default. A transcript can be thousands of words and
+ * twenty of them stacked would bury the list this card exists to show.
+ */
+import { computed, onMounted, ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import CollapsibleCard from '../ui/CollapsibleCard.vue'
+import {
+  useCallHistory,
+  formatDuration,
+  formatUsd,
+  formatWhen,
+  parseTranscript,
+  transcriptToText,
+  type CallEntry,
+} from '../../composables/useCallHistory'
+
+const props = defineProps<{
+  notify: (msg: string, kind?: 'error' | 'success', ms?: number) => void
+  /** Whether calls are recorded at all. Persisted by the parent. */
+  recording: boolean
+  /** One of keep_all | days_7 | days_30 | months_3 | last_50. */
+  retention: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:recording', value: boolean): void
+  (e: 'update:retention', value: string): void
+}>()
+
+const history = useCallHistory()
+
+/** Ids whose transcript is unfolded. */
+const expanded = ref<Set<number>>(new Set())
+
+function toggleExpanded(id: number) {
+  const next = new Set(expanded.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expanded.value = next
+}
+
+const RETENTION_OPTIONS = [
+  { value: 'days_7', label: 'Keep for 7 days' },
+  { value: 'days_30', label: 'Keep for 30 days' },
+  { value: 'months_3', label: 'Keep for 3 months' },
+  { value: 'last_50', label: 'Keep the last 50 calls' },
+  { value: 'keep_all', label: 'Keep everything' },
+]
+
+const summary = computed(() => {
+  const s = history.stats.value
+  if (!s || s.calls === 0) return 'Nothing recorded yet'
+  const spend = formatUsd(s.cost_usd)
+  const parts = [`${s.calls} call${s.calls === 1 ? '' : 's'}`, formatDuration(s.duration_ms)]
+  if (spend) parts.push(`~${spend}${s.unpriced > 0 ? '+' : ''}`)
+  return parts.join(' · ')
+})
+
+/**
+ * Warn when the total is known to be incomplete rather than quietly showing a
+ * smaller number. A call on a model with no rate table is not a free call.
+ */
+const summaryTitle = computed(() => {
+  const s = history.stats.value
+  if (!s) return ''
+  const lines = [`${s.calls} recorded calls, ${formatDuration(s.duration_ms)} in total.`]
+  if (s.unpriced > 0) {
+    lines.push(
+      `${s.unpriced} of them ran on a model with no known rates and are not included in the total.`,
+    )
+  }
+  lines.push('Cost is an estimate. Token counts are exact.')
+  return lines.join('\n')
+})
+
+function turnsOf(entry: CallEntry) {
+  return parseTranscript(entry.transcript)
+}
+
+function tokenLine(entry: CallEntry): string {
+  const n = (v: number) => v.toLocaleString()
+  return [
+    `Audio in ${n(entry.audio_in)} (+${n(entry.audio_in_cached)} cached)`,
+    `Audio out ${n(entry.audio_out)}`,
+    `Text in ${n(entry.text_in)} (+${n(entry.text_in_cached)} cached)`,
+    `Text out ${n(entry.text_out)}`,
+    `${entry.responses} response${entry.responses === 1 ? '' : 's'}`,
+  ].join(' · ')
+}
+
+async function copyOne(entry: CallEntry) {
+  const text = transcriptToText(turnsOf(entry))
+  if (!text.trim()) { props.notify('Nothing was said on that call', 'error'); return }
+  try {
+    await invoke('copy_text_to_clipboard', { text })
+    props.notify('Transcript copied', 'success')
+  } catch (e: any) {
+    props.notify(e?.message || 'Copy failed', 'error')
+  }
+}
+
+/**
+ * Paste a past transcript into whatever the user was last working in.
+ *
+ * The same dance the live panel does: this window holds focus while the button
+ * is clicked, so the previous application has to be brought forward first. The
+ * clipboard copy happens regardless, so the text is never lost if the paste
+ * does not land.
+ */
+async function insertOne(entry: CallEntry) {
+  const text = transcriptToText(turnsOf(entry)).trim()
+  if (!text) { props.notify('Nothing was said on that call', 'error'); return }
+  try { await invoke('copy_text_to_clipboard', { text }) } catch {}
+  try {
+    await invoke('refocus_previous_app')
+    await new Promise((r) => setTimeout(r, 80))
+    await invoke('insert_text_into_focused_app', { text })
+  } catch (e: any) {
+    props.notify((e?.message || 'Insert failed') + ' - the text is on the clipboard.', 'error')
+  }
+}
+
+/**
+ * Deleting is not undoable, so it asks - but only once per press, and the
+ * question names what is about to go.
+ */
+const confirmingClear = ref<'' | 'unpinned' | 'all'>('')
+
+async function doClear(which: 'unpinned' | 'all') {
+  if (confirmingClear.value !== which) { confirmingClear.value = which; return }
+  confirmingClear.value = ''
+  const removed = await history.clear(which === 'unpinned')
+  props.notify(`Deleted ${removed} call${removed === 1 ? '' : 's'}`, 'success')
+}
+
+/** Reload from disk. Exposed so the parent can call it after a call ends. */
+async function reload() {
+  await history.refresh()
+}
+
+defineExpose({ reload })
+
+onMounted(() => { void history.refresh() })
+</script>
+
+<template>
+  <CollapsibleCard
+    id="assistant.history"
+    title="Call history"
+    :desc="summary"
+    :default-open="false"
+  >
+    <div class="field-grid">
+      <div class="field">
+        <label class="switch row">
+          <input
+            type="checkbox"
+            :checked="props.recording"
+            @change="emit('update:recording', ($event.target as HTMLInputElement).checked)"
+          />
+          <span class="switch-text">
+            <span class="switch-label">Record calls</span>
+            <span class="switch-hint">
+              Saves the duration, model, token counts, estimated cost and full transcript of each
+              call to <code>calls.db</code> beside your settings. Transcripts are stored as plain
+              text. Turning this off stops new calls being recorded and leaves what is already
+              there.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <div class="field">
+        <label class="field-label">Keep calls for</label>
+        <select
+          class="input"
+          :value="props.retention"
+          :disabled="!props.recording"
+          @change="emit('update:retention', ($event.target as HTMLSelectElement).value)"
+        >
+          <option v-for="o in RETENTION_OPTIONS" :key="o.value" :value="o.value">{{ o.label }}</option>
+        </select>
+        <p class="field-hint">
+          Applied after every call and once when the app starts. Pinned calls are never removed by
+          this.
+        </p>
+      </div>
+    </div>
+
+    <p v-if="history.error.value" class="field-hint error">{{ history.error.value }}</p>
+
+    <div class="divider"></div>
+
+    <p v-if="history.loaded.value && !history.entries.value.length" class="field-hint">
+      No calls recorded yet. One appears here as soon as you hang up.
+    </p>
+
+    <ol v-else class="calls">
+      <li v-for="entry in history.entries.value" :key="entry.id" class="call" :class="{ open: expanded.has(entry.id) }">
+        <div class="call-head">
+          <button
+            type="button"
+            class="call-summary"
+            :aria-expanded="expanded.has(entry.id)"
+            @click="toggleExpanded(entry.id)"
+          >
+            <svg class="chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="m6 4 4 4-4 4" />
+            </svg>
+            <span class="call-when">{{ formatWhen(entry.started_at) }}</span>
+            <span class="call-title">{{ entry.title }}</span>
+            <span class="call-meta">
+              <span class="badge">{{ formatDuration(entry.duration_ms) }}</span>
+              <span class="badge" :title="tokenLine(entry)">
+                {{ formatUsd(entry.cost_usd) ?? 'unpriced' }}
+              </span>
+            </span>
+          </button>
+
+          <button
+            type="button"
+            class="icon-btn"
+            :class="{ on: entry.saved }"
+            :title="entry.saved ? 'Pinned - kept regardless of the retention setting' : 'Pin this call so it is never expired'"
+            :aria-pressed="entry.saved"
+            @click="history.togglePin(entry)"
+          >
+            <svg viewBox="0 0 16 16" :fill="entry.saved ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" aria-hidden="true">
+              <path d="M8 1.8 10 6l4.4.5-3.3 3 .9 4.4L8 11.7 4 13.9l.9-4.4-3.3-3L6 6z" />
+            </svg>
+          </button>
+
+          <button type="button" class="icon-btn danger" title="Delete this call" @click="history.remove(entry)">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true">
+              <path d="M3 4.5h10M6.5 4.5V3h3v1.5M4.5 4.5l.6 8.2h5.8l.6-8.2" />
+            </svg>
+          </button>
+        </div>
+
+        <div v-if="expanded.has(entry.id)" class="call-body">
+          <p class="call-facts">
+            <span class="badge">{{ entry.model }}</span>
+            <span class="badge">{{ entry.voice }}</span>
+            <span v-if="entry.tools_enabled" class="badge">MCP tools</span>
+            <span v-if="entry.supervisor" class="badge">supervisor: {{ entry.supervisor }}</span>
+          </p>
+          <p class="call-tokens">{{ tokenLine(entry) }}</p>
+
+          <ol class="turns">
+            <li v-for="(t, i) in turnsOf(entry)" :key="i" class="turn" :class="t.role">
+              <span class="turn-who">{{ t.role === 'user' ? 'You' : (t.role === 'tool' ? 'Tool' : 'Assistant') }}</span>
+              <span class="turn-text">{{ t.content }}</span>
+            </li>
+          </ol>
+          <p v-if="!turnsOf(entry).length" class="field-hint">No transcript was captured for this call.</p>
+
+          <div class="actions">
+            <button class="btn ghost" type="button" @click="copyOne(entry)">Copy transcript</button>
+            <button class="btn ghost" type="button" @click="insertOne(entry)">Insert into previous app</button>
+          </div>
+        </div>
+      </li>
+    </ol>
+
+    <div class="actions" v-if="history.entries.value.length">
+      <button
+        v-if="history.hasMore.value"
+        class="btn ghost"
+        type="button"
+        :disabled="history.loading.value"
+        @click="history.loadMore()"
+      >
+        {{ history.loading.value ? 'Loading…' : 'Load more' }}
+      </button>
+      <span class="spacer"></span>
+      <!-- Neutral until armed, red once a second click would actually delete.
+           The button that is one press from destroying something should not
+           look the same as the one that only asks. -->
+      <button
+        :class="confirmingClear === 'unpinned' ? 'btn danger' : 'btn ghost'"
+        type="button"
+        @click="doClear('unpinned')"
+        @blur="confirmingClear = ''"
+      >
+        {{ confirmingClear === 'unpinned' ? 'Click again to delete unpinned' : 'Delete unpinned' }}
+      </button>
+      <button
+        :class="confirmingClear === 'all' ? 'btn danger' : 'btn ghost'"
+        type="button"
+        @click="doClear('all')"
+        @blur="confirmingClear = ''"
+      >
+        {{ confirmingClear === 'all' ? 'Click again to delete everything' : 'Delete all' }}
+      </button>
+    </div>
+
+    <p class="field-hint" :title="summaryTitle">
+      Costs are estimates from a rate table in this app, not from your OpenAI invoice. Token counts
+      are exactly what the API reported.
+    </p>
+  </CollapsibleCard>
+</template>
+
+<style scoped>
+.calls {
+  list-style: none;
+  margin: 0 0 var(--sp-3);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.call { border-bottom: 1px solid var(--adc-border); }
+.call:last-child { border-bottom: 0; }
+
+.call-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+}
+
+.call-summary {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: grid;
+  /* Chevron, timestamp, title, then the numbers pinned to the right. The
+     timestamp column is fixed so the titles line up down the list instead of
+     stepping in and out with the length of each date. */
+  grid-template-columns: 16px minmax(0, max-content) minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: var(--sp-2);
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  padding: var(--sp-2) var(--sp-1);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+.call-summary:hover { background: var(--adc-hover); }
+.call-summary:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--adc-accent); }
+
+.chevron {
+  width: 16px;
+  height: 16px;
+  color: var(--adc-fg-muted);
+  transition: transform 0.18s ease;
+}
+.open .chevron { transform: rotate(90deg); }
+
+.call-when {
+  color: var(--adc-fg-muted);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.call-title {
+  color: var(--adc-fg);
+  font-size: var(--fs-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.call-meta {
+  display: flex;
+  gap: var(--sp-1);
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.icon-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  appearance: none;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--adc-fg-muted);
+  cursor: pointer;
+}
+.icon-btn svg { width: 15px; height: 15px; }
+.icon-btn:hover { background: var(--adc-hover); color: var(--adc-fg); }
+.icon-btn:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--adc-accent); }
+.icon-btn.on { color: var(--adc-accent); }
+.icon-btn.danger:hover { color: var(--adc-danger); }
+
+.call-body {
+  padding: 0 var(--sp-1) var(--sp-3) calc(16px + var(--sp-2) + var(--sp-1));
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+.call-facts { display: flex; flex-wrap: wrap; gap: var(--sp-1); margin: 0; }
+.call-tokens {
+  margin: 0;
+  color: var(--adc-fg-muted);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.turns {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  max-height: 320px;
+  overflow: auto;
+  user-select: text;
+}
+.turn {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: var(--sp-3);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+.turn-who {
+  color: var(--adc-fg-muted);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-top: 2px;
+}
+.turn.user .turn-who { color: var(--adc-accent); }
+.turn-text { color: var(--adc-fg); overflow-wrap: anywhere; white-space: pre-wrap; }
+.turn.tool .turn-text {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--adc-fg-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron { transition: none; }
+}
+</style>

--- a/app/src/composables/useCallHistory.ts
+++ b/app/src/composables/useCallHistory.ts
@@ -1,0 +1,240 @@
+import { ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+
+/**
+ * The saved record of past Assistant Mode calls.
+ *
+ * Backed by SQLite in Rust (`call_history.rs`) rather than a JSON file: calls
+ * arrive one at a time and are read back newest-first a page at a time, and the
+ * running spend is a SUM rather than a full parse.
+ *
+ * Field names are snake_case because they are the database columns, and the
+ * Rust struct is serialized as declared - only the *arguments* of a Tauri
+ * command are camelCased on the way through.
+ */
+export interface CallEntry {
+  id: number
+  /** Unix seconds the call connected. */
+  started_at: number
+  duration_ms: number
+  model: string
+  voice: string
+  /** Pinned. Pinned calls survive every retention sweep. */
+  saved: boolean
+  title: string
+  /** JSON array of `{ role, content }`. */
+  transcript: string
+  turns: number
+  responses: number
+  audio_in: number
+  audio_in_cached: number
+  audio_out: number
+  text_in: number
+  text_in_cached: number
+  text_out: number
+  /** null when the model had no known rates - not the same as zero. */
+  cost_usd: number | null
+  tools_enabled: boolean
+  supervisor: string | null
+}
+
+/** What the frontend supplies; the id and pin are the store's business. */
+export type CallDraft = Omit<CallEntry, 'id' | 'saved'>
+
+export interface CallStats {
+  calls: number
+  duration_ms: number
+  /** Total over the calls that had known rates. */
+  cost_usd: number
+  /** How many calls could not be priced, so the total is known to be partial. */
+  unpriced: number
+}
+
+export interface TranscriptTurn { role: string, content: string }
+
+const PAGE_SIZE = 25
+
+/** Longest title kept. Enough to recognise a call, short enough for one line. */
+const TITLE_MAX = 90
+
+/**
+ * A one-line label for a call, taken from the first thing the user said.
+ *
+ * Falls back to the assistant's opening line, because a call where the user
+ * only listened is still worth finding again.
+ */
+export function titleFor(turns: TranscriptTurn[]): string {
+  const spoken = turns.filter((t) => t.role === 'user' || t.role === 'assistant')
+  const first = spoken.find((t) => t.role === 'user') ?? spoken[0]
+  const text = String(first?.content ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return 'No speech'
+  return text.length > TITLE_MAX ? text.slice(0, TITLE_MAX - 1).trimEnd() + '…' : text
+}
+
+/** "4:07", or "12s" under a minute. */
+export function formatDuration(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000))
+  if (total < 60) return `${total}s`
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/**
+ * "$0.0412" below a cent-ish, "$1.23" above.
+ *
+ * Four decimals matter here: a short call on the mini model genuinely costs
+ * fractions of a cent, and rounding those to $0.00 would make the whole column
+ * look free.
+ */
+export function formatUsd(value: number | null | undefined): string | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) return null
+  return value < 0.01 ? `$${value.toFixed(4)}` : `$${value.toFixed(2)}`
+}
+
+/** Local date and time, to the minute. */
+export function formatWhen(startedAtSeconds: number): string {
+  const d = new Date(startedAtSeconds * 1000)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  })
+}
+
+export function parseTranscript(json: string): TranscriptTurn[] {
+  try {
+    const parsed = JSON.parse(json)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter((t: any) => t && typeof t === 'object')
+      .map((t: any) => ({ role: String(t.role ?? ''), content: String(t.content ?? '') }))
+  } catch {
+    // A row written by a future version, or a truncated write. Showing nothing
+    // is better than throwing inside a list render.
+    return []
+  }
+}
+
+/** The conversation as plain text, tool calls left out. */
+export function transcriptToText(turns: TranscriptTurn[]): string {
+  return turns
+    .filter((t) => t.role !== 'tool')
+    .map((t) => `${t.role === 'user' ? 'You' : 'Assistant'}: ${t.content}`)
+    .join('\n\n')
+}
+
+export function useCallHistory() {
+  const entries = ref<CallEntry[]>([])
+  const stats = ref<CallStats | null>(null)
+  const hasMore = ref(false)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  /** True once the list has been fetched, so an empty list can say "none yet". */
+  const loaded = ref(false)
+
+  function fail(e: any, what: string) {
+    error.value = typeof e === 'string' ? e : (e?.message || what)
+  }
+
+  async function refreshStats() {
+    try {
+      stats.value = await invoke<CallStats>('call_history_stats')
+    } catch (e) {
+      // The list is the feature; a missing total should not blank it.
+      stats.value = null
+    }
+  }
+
+  /** Reload the first page, discarding anything already loaded. */
+  async function refresh() {
+    loading.value = true
+    error.value = null
+    try {
+      const page = await invoke<{ entries: CallEntry[], has_more: boolean }>('call_history_list', {
+        cursor: null,
+        limit: PAGE_SIZE,
+      })
+      entries.value = page.entries ?? []
+      hasMore.value = page.has_more === true
+      loaded.value = true
+    } catch (e) {
+      fail(e, 'Could not read the call history')
+    } finally {
+      loading.value = false
+    }
+    void refreshStats()
+  }
+
+  async function loadMore() {
+    const last = entries.value[entries.value.length - 1]
+    if (!last || loading.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const page = await invoke<{ entries: CallEntry[], has_more: boolean }>('call_history_list', {
+        cursor: last.id,
+        limit: PAGE_SIZE,
+      })
+      entries.value = entries.value.concat(page.entries ?? [])
+      hasMore.value = page.has_more === true
+    } catch (e) {
+      fail(e, 'Could not read more calls')
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Record a finished call.
+   *
+   * Resolves to the new id, or null when recording is switched off in settings -
+   * the decision is made in Rust so the caller does not have to read the setting
+   * to know whether to bother.
+   */
+  async function save(draft: CallDraft): Promise<number | null> {
+    try {
+      const id = await invoke<number | null>('call_history_save', { entry: { ...draft, id: 0, saved: false } })
+      return typeof id === 'number' ? id : null
+    } catch (e) {
+      fail(e, 'Could not save the call')
+      return null
+    }
+  }
+
+  async function togglePin(entry: CallEntry) {
+    const next = !entry.saved
+    try {
+      await invoke('call_history_set_saved', { id: entry.id, saved: next })
+      entry.saved = next
+    } catch (e) {
+      fail(e, 'Could not pin the call')
+    }
+  }
+
+  async function remove(entry: CallEntry) {
+    try {
+      await invoke('call_history_delete', { id: entry.id })
+      entries.value = entries.value.filter((e) => e.id !== entry.id)
+      void refreshStats()
+    } catch (e) {
+      fail(e, 'Could not delete the call')
+    }
+  }
+
+  /** Delete everything, or everything not pinned. Returns how many went. */
+  async function clear(keepSaved: boolean): Promise<number> {
+    try {
+      const removed = await invoke<number>('call_history_clear', { keepSaved })
+      await refresh()
+      return typeof removed === 'number' ? removed : 0
+    } catch (e) {
+      fail(e, 'Could not clear the call history')
+      return 0
+    }
+  }
+
+  return {
+    entries, stats, hasMore, loading, loaded, error,
+    refresh, loadMore, save, togglePin, remove, clear,
+  }
+}


### PR DESCRIPTION
Assistant Mode now keeps a record of every call: when it ran, how long for, what it cost, and what was said.

A realtime call is billed per audio token, so the only honest answer to "what am I spending on this" is a record of the calls themselves. Until now each one vanished the moment the panel was closed.

## Backend - `app/src-tauri/src/call_history.rs`

SQLite (`calls.db`, beside `settings.json`) via `rusqlite` + `rusqlite_migration`. The first SQLite in the app; everything else stays JSON. The reason is the access pattern: calls arrive one at a time and are read back newest-first a page at a time, and the lifetime spend is a `SUM()` rather than a full parse.

- Paging is **by id, not offset**, so a page boundary stays put even if a call is deleted or recorded while the list is open.
- `cost_usd` is **nullable** and stays null for a model with no known rates. "We do not know what this cost" and "this was free" must not read the same, so the stats query counts unpriced calls separately instead of folding them in as zero.
- Retention (30 days by default) **never touches a pinned call**. That is the point of the pin.
- Both settings live inside the existing `assistant_realtime` blob, which `save_settings` persists wholesale, so neither needs an allowlist entry.
- The sweep runs once at startup on a worker thread, and again after every call.

Nine tests against an in-memory database cover the round trip, paging, both retention policies, the unpriced case and the clear-but-keep-pinned path.

## Frontend - `CallHistory.vue`, `useCallHistory.ts`

A collapsible card listing calls newest first, each row folding open to its transcript, token breakdown, and copy / insert-into-previous-app buttons. The header carries the running total even while closed.

Three details worth knowing:

- The duration clock starts at `onConnected`, not at `activate`, so a slow token mint or ICE negotiation is not billed to the call.
- `onDisconnected` is **not** fired once per call - an ICE state change raises it and the hang-up that follows raises it again - so a guard is set synchronously before the first `await`, or every call would be recorded twice.
- A session that connected but produced neither speech nor a billable response is not written at all.

## Privacy

Recording is on by default and the hint says plainly that transcripts are stored as plain text next to `settings.json` - the same bargain that file already makes with the API key. It can be switched off, which stops new calls being recorded and leaves what is already there. Delete asks first, and the confirm button turns red only when a second press would actually delete.

## Verification

- `cargo test --lib`: 39 passed, 0 failed (9 new).
- `npm run build` (vue-tsc + vite): clean.
- Running dev app restarted onto the new binary and created `calls.db` with the expected schema and index at startup.

Not yet exercised end to end through the UI - that needs a real call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)