### PR TITLE
fix(ci): stop a failed build poisoning the cache for every later run

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -27,12 +27,24 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      # `cache-on-failure` is deliberately off. With it on, a run that failed
+      # still saved its `app/src-tauri/target`, so one broken build state was
+      # handed to every run after it and the job could never heal itself.
+      #
+      # That is not hypothetical: this workflow failed on every merge from
+      # 4df7261 (21 Aug, the ort rc.13 -> rc.10 downgrade) until 26 Aug, always
+      # in the WiX `light.exe` step. The same commit went green the moment the
+      # cache was deleted, with no code change. `release-windows.yml` kept
+      # working throughout only because rust-cache puts the job id in its key,
+      # so it had a separate lineage that never took the bad state.
+      #
+      # Off, a failed run simply saves nothing and the next one restores the
+      # last cache that came from a build that actually worked.
       - name: Cache Rust (Cargo + target)
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             app/src-tauri
-          cache-on-failure: true
 
       - name: Install WiX Toolset (for MSI bundling)
         run: choco install wixtoolset -y --no-progress
@@ -55,9 +67,14 @@ jobs:
       #     [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_CERT_PFX_BASE64))
       #     echo "CERT_PATH=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      # `npm ci`, matching `release-windows.yml`. `npm install` is free to
+      # resolve something the lockfile does not name, so what this job built was
+      # not necessarily what the release job would build. The two jobs quietly
+      # differing is what made the failure above so confusing: the same command
+      # was green in one and red in the other.
       - name: Install frontend dependencies
         working-directory: app
-        run: npm install
+        run: npm ci
 
       - name: Build Tauri app (Windows release)
         working-directory: app

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -38,12 +38,15 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      # Off for the same reason as in `build-windows.yml` - see the note there.
+      # A failed run must not hand its build state to the next one; this job
+      # escaped that outage only by having a separate cache key, not by being
+      # configured any more safely.
       - name: Cache Rust (Cargo + target)
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             app/src-tauri
-          cache-on-failure: true
 
       - name: Install WiX Toolset (for MSI bundling)
         run: choco install wixtoolset -y --no-progress


### PR DESCRIPTION
The Windows installer build has failed on **every merge since 21 August** - #15, #16, #17, #18 and #19 - always in the WiX `light.exe` step, with no error text because Tauri swallows the bundler output.

**The code was never the problem.** I deleted the Actions cache and re-ran the exact same commit (`d1aa14a`), unchanged: it went green and produced a 174 MB artifact.

## What happened

`4df7261` ("stay on the CUDA 12 ONNX Runtime") downgraded ort rc.13 to rc.10, which changes the ONNX Runtime DLLs downloaded into `app/src-tauri/target`. That left the cached target directory in a state the bundler could not use.

`cache-on-failure: true` then made it permanent: every failed run saved that state again, so every later run restored the same broken directory. The job could not heal itself, and would not have until someone cleared a cache by hand.

## Why the release job kept working

`release-windows.yml` runs the identical `npm run tauri -- build` and has succeeded throughout - v0.1.21 shipped a **162 MB MSI** on 26 August. It is not configured any more safely. `Swatinem/rust-cache` puts the **job id** in its key:

```
v0-rust-build-windows-Windows_NT-x64-368f6b88-…    ← poisoned
v0-rust-release-windows-Windows_NT-x64-368f6b88-…  ← clean
```

Two separate lineages. The release one never failed, so it never took the bad state. That divergence is what made this hard to read - the same command was green in one job and red in the other, which points away from the cache rather than at it.

## The change

- `cache-on-failure` comes off **both** jobs. A failed run now saves nothing and the next restores the last cache from a build that actually worked. Recovery costs a recompile from the previous good cache - a good trade against a job that stays broken indefinitely.
- `build-windows.yml` switches `npm install` to `npm ci`, matching the release job. `npm install` may resolve something the lockfile does not name, so the two jobs were not building the same thing.

The 7 poisoned caches are already deleted and `build-windows` is green on `d1aa14a`.

## Verification

- Same commit, cleared cache, no code change: **completed/success**, artifact `AiDesktopCompanion-windows` 174 MB.
- Both workflow files parse as YAML.

Note this does **not** get call history onto an installed copy: CI uploads an artifact, not a release, and the in-app updater reads `releases/latest`, where v0.1.21 predates the merge. That needs a version bump and a `v0.1.22` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)