### PR TITLE
fix(app): actually stop the OpenAI TTS streaming session

### DIFF
--- a/app/src/composables/useTtsPlayback.ts
+++ b/app/src/composables/useTtsPlayback.ts
@@ -259,9 +259,32 @@ export function useTtsPlayback(notify?: NotifyFn) {
     }
     a.onended = () => {
       speaking.value = false
-      if (streamSessionId) { invoke('tts_stop_stream_session', { session_id: streamSessionId }).catch(() => {}) }
-      streamSessionId = null
+      void releaseStreamSession()
       streamSessionUrl.value = ''
+    }
+  }
+
+  /**
+   * Release the streaming session held by the backend.
+   *
+   * Never throws: this is cleanup, and a failure must not break playback or
+   * leave the player stuck. It does log, which it did not before - the two
+   * callers each discarded the error, so the fact that this call had never once
+   * succeeded was invisible. The argument was `session_id`, and Tauri looks a
+   * command argument up in its camelCase form, so `sessionId` never arrived and
+   * every call failed on a missing required parameter.
+   *
+   * Clears the id before the call, so a second stop cannot race the first into
+   * trying to release the same session twice.
+   */
+  async function releaseStreamSession() {
+    const id = streamSessionId
+    streamSessionId = null
+    if (!id) return
+    try {
+      await invoke('tts_stop_stream_session', { sessionId: id })
+    } catch (e) {
+      console.warn('[tts] could not stop stream session', id, e)
     }
   }
 
@@ -274,8 +297,7 @@ export function useTtsPlayback(notify?: NotifyFn) {
       try { (a as any).onended = null } catch {}
       if (streamSessionUrl.value && a.src === streamSessionUrl.value) { a.src = '' }
     }
-    if (streamSessionId) { try { await invoke('tts_stop_stream_session', { session_id: streamSessionId }) } catch {} }
-    streamSessionId = null
+    await releaseStreamSession()
     streamSessionUrl.value = ''
     speaking.value = false
     busy.value = false


### PR DESCRIPTION
## The bug

`tts_stop_stream_session` takes a **required** `session_id: String`. Tauri looks a command argument up in its camelCase form, so the payload had to say `sessionId`. Both callers in `useTtsPlayback.ts` sent `session_id`, so the argument never arrived and **every call failed** on a missing required parameter.

Neither caller would have noticed - one was `.catch(() => {})`, the other a bare `try/catch {}`. A call that had never once succeeded looked identical to one that always did.

**Effect:** the OpenAI TTS streaming session stayed alive on the backend after playback ended or was stopped, until `stream_cleanup_idle` reaped it on its TTL. Sessions leak for the length of that window.

## The fix

Both call sites now go through one `releaseStreamSession`, which:

- sends `sessionId`, so the call actually reaches the command;
- still cannot throw - cleanup must not break playback or leave the player stuck - but **logs** rather than discarding, so the next failure here is visible;
- clears the id before invoking, so a manual stop racing an `onended` cannot try to release the same session twice.

## Deliberately not changed

The `safe_mode: false` payloads in `QuickActions.vue`, `AssistantMode.vue` and `main.ts` are the same mistake, but harmless: those parameters are `Option<bool>` read with `unwrap_or(false)`, so the argument going missing produces exactly the intended value. Changing them would be churn.

I swept every `invoke` in the frontend for snake_case argument keys. This was the only one that mattered - the rest are either `Option`, already camelCase, or nested fields inside the `save_settings` payload, which are serde field names and correctly snake_case.

## Verification

`npm run build` (vue-tsc + vite) clean. Not exercised at runtime - that needs OpenAI TTS with streaming on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)